### PR TITLE
added imagePullSecrets to be included in ManifestWork

### DIFF
--- a/internals/utils/volumes.go
+++ b/internals/utils/volumes.go
@@ -27,7 +27,10 @@ func prepareVolumesManifests(secrets []string, configMaps []string, capp rcsv1al
 			return resources, err
 		} else {
 			cmManifest := &corev1.ConfigMap{
-				TypeMeta: metav1.TypeMeta{},
+				TypeMeta: metav1.TypeMeta{
+					Kind: "ConfigMap",
+					APIVersion: "v1",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      cm.Name,
 					Namespace: cm.Namespace,
@@ -44,7 +47,10 @@ func prepareVolumesManifests(secrets []string, configMaps []string, capp rcsv1al
 			return resources, err
 		} else {
 			secretManifest := &corev1.Secret{
-				TypeMeta: metav1.TypeMeta{},
+				TypeMeta: metav1.TypeMeta{
+					Kind: "Secret",
+					APIVersion: "v1",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      secret.Name,
 					Namespace: secret.Namespace,
@@ -59,6 +65,7 @@ func prepareVolumesManifests(secrets []string, configMaps []string, capp rcsv1al
 
 // This function takes in a Capp object, a context.Context, a logr.Logger, and a Kubernetes client object. It returns two lists of strings, one for ConfigMaps and one for Secrets.
 // This function iterates over the ContainerSpec objects specified in the Capp object and extracts the names of any ConfigMaps or Secrets specified in their EnvFrom fields.
+// Additionally, it extracts the names of secrets located in the imagePullSecrets field.
 // It also iterates over the Volumes specified in the Capp object and extracts the names of any ConfigMaps or Secrets specified in them.
 func GetResourceVolumesFromContainerSpec(capp rcsv1alpha1.Capp, ctx context.Context, l logr.Logger, r client.Client) ([]string, []string) {
 	var configMaps []string
@@ -81,6 +88,9 @@ func GetResourceVolumesFromContainerSpec(capp rcsv1alpha1.Capp, ctx context.Cont
 		if volume.Secret != nil {
 			secrets = append(secrets, volume.Secret.SecretName)
 		}
+	}
+	for _, secret := range capp.Spec.ConfigurationSpec.Template.Spec.ImagePullSecrets {
+		secrets = append(secrets, secret.Name)
 	}
 
 	return configMaps, secrets


### PR DESCRIPTION
Fixes #11. Added imagePullSecrets to ManifestWork, and in the process added TypeMeta to secrets and configmaps.
Signed-off-by: Omer Ben David <omerbendavid21@gmail.com>