### PR TITLE
Added the defaults webhook, its unit testing and a KuTTL e2e test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ testbin/*
 *.swp
 *.swo
 *~
+
+kubeconfig

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/go-logr/logr v1.2.3
+	github.com/onsi/gomega v1.24.1
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
@@ -16,7 +17,6 @@ require (
 require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/magefile/mage v1.9.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.8.2 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -229,6 +229,7 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo/v2 v2.6.0 h1:9t9b9vRUbFq3C4qKFCGkVuq/fIHji802N1nrtkh1mNc=
 github.com/onsi/gomega v1.24.1 h1:KORJXNNTzJXzu4ScJWssJfJMnJ+2QJqhoQSRwNlze9E=
+github.com/onsi/gomega v1.24.1/go.mod h1:3AOiACssS3/MajrniINInwbfOOtfZvplPzuRSmvt1jM=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -280,7 +281,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
@@ -658,8 +658,6 @@ open-cluster-management.io/api v0.10.0/go.mod h1:6BB/Y6r3hXlPjpJgDwIs6Ubxyx/kXXO
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/controller-runtime v0.14.4 h1:Kd/Qgx5pd2XUL08eOV2vwIq3L9GhIbJ5Nxengbd4/0M=
-sigs.k8s.io/controller-runtime v0.14.4/go.mod h1:WqIdsAY6JBsjfc/CqO0CORmNtoCtE4S6qbPc9s68h+0=
 sigs.k8s.io/controller-runtime v0.14.6 h1:oxstGVvXGNnMvY7TAESYk+lzr6S3V5VFxQ6d92KcwQA=
 sigs.k8s.io/controller-runtime v0.14.6/go.mod h1:WqIdsAY6JBsjfc/CqO0CORmNtoCtE4S6qbPc9s68h+0=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN1p0AC/kzH07hu3NE+k=

--- a/internals/webhooks/capp_validation_utils.go
+++ b/internals/webhooks/capp_validation_utils.go
@@ -24,7 +24,7 @@ func isSiteClusterName(capp rcsv1alpha1.Capp, r client.Client, ctx context.Conte
 		return true
 	}
 	clusters, _ := getManagedClusters(r, ctx)
-	return slices.Contains(clusters, capp.Spec.ScaleMetric)
+	return slices.Contains(clusters, capp.Spec.Site)
 
 }
 

--- a/internals/webhooks/capp_webhook.go
+++ b/internals/webhooks/capp_webhook.go
@@ -3,33 +3,31 @@ package webhooks
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	rcsv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 
-	"net/http"
-
-	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 type CappValidator struct {
 	Client  client.Client
 	Decoder *admission.Decoder
-	Log     logr.Logger
 }
 
-// +kubebuilder:webhook:path=/validate-capp,mutating=false,sideEffects=NoneOnDryRun,failurePolicy=fail,groups="rcs.dana.io",resources=capp,verbs=create;update,versions=v1,name=capp.rcs.dana.io,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:path=/validate-capp,mutating=false,sideEffects=NoneOnDryRun,failurePolicy=fail,groups="rcs.dana.io",resources=capps,verbs=create;update,versions=v1alpha1,name=capp.validate.rcs.dana.io,admissionReviewVersions=v1;v1beta1
 
 const ServingPath = "/validate-capp"
 
 func (c *CappValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
-	log := c.Log.WithValues("webhook", "capp Webhook", "Name", req.Name)
-	log.Info("webhook request received")
+	logger := log.FromContext(ctx).WithValues("webhook", "capp Webhook", "Name", req.Name)
+	logger.Info("webhook request received")
 	capp := rcsv1alpha1.Capp{}
-	if err := c.Decoder.DecodeRaw(req.OldObject, &capp); err != nil {
-		log.Error(err, "could not decode capp object")
+	if err := c.Decoder.DecodeRaw(req.Object, &capp); err != nil {
+		logger.Error(err, "could not decode capp object")
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 	return c.handle(ctx, req, capp)

--- a/internals/webhooks/defaults_webhook.go
+++ b/internals/webhooks/defaults_webhook.go
@@ -1,0 +1,49 @@
+package webhooks
+
+import (
+	"context"
+	"encoding/json"
+
+	rcsv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+
+	"net/http"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type DefaultMutator struct {
+	Client  client.Client
+	Decoder *admission.Decoder
+}
+
+// +kubebuilder:webhook:path=/mutate-defaults-capp,mutating=true,sideEffects=NoneOnDryRun,failurePolicy=fail,groups="rcs.dana.io",resources=capps,verbs=create;update,versions=v1alpha1,name=capp.mutate.rcs.dana.io,admissionReviewVersions=v1;v1beta1
+
+const (
+	DefaultsServingPath = "/mutate-defaults-capp"
+	DefaultScaleMetric  = "cpu"
+)
+
+func (c *DefaultMutator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	logger := log.FromContext(ctx).WithValues("webhook", "capp defaults Webhook", "Name", req.Name)
+	logger.Info("webhook request received")
+	capp := rcsv1alpha1.Capp{}
+	if err := c.Decoder.DecodeRaw(req.Object, &capp); err != nil {
+		logger.Error(err, "could not decode capp object")
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	c.handle(&capp)
+	marshaledCapp, err := json.Marshal(capp)
+	if err != nil {
+		admission.Errored(http.StatusInternalServerError, err)
+	}
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledCapp)
+
+}
+
+func (c *DefaultMutator) handle(capp *rcsv1alpha1.Capp) {
+	if capp.Spec.ScaleMetric == "" {
+		capp.Spec.ScaleMetric = DefaultScaleMetric
+	}
+}

--- a/internals/webhooks/defaults_webhook_test.go
+++ b/internals/webhooks/defaults_webhook_test.go
@@ -18,10 +18,10 @@ type TestCase struct {
 func TestDefaultsWebhook(t *testing.T) {
 	tests := []TestCase{
 		{
-			cappName: "i-forgot-metric",
+			cappName: "withoutScaleMetric",
 			mutated:  true,
 		}, {
-			cappName:    "i-put-metric",
+			cappName:    "withScaleMetric",
 			scaleMetric: "cpu",
 			mutated:     false,
 		},

--- a/internals/webhooks/defaults_webhook_test.go
+++ b/internals/webhooks/defaults_webhook_test.go
@@ -1,0 +1,56 @@
+package webhooks
+
+import (
+	"testing"
+
+	rcsv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
+)
+
+type TestCase struct {
+	cappName    string
+	scaleMetric string
+	mutated     bool
+}
+
+func TestDefaultsWebhook(t *testing.T) {
+	tests := []TestCase{
+		{
+			cappName: "i-forgot-metric",
+			mutated:  true,
+		}, {
+			cappName:    "i-put-metric",
+			scaleMetric: "cpu",
+			mutated:     false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.cappName, func(t *testing.T) {
+			capp := rcsv1alpha1.Capp{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tc.cappName,
+				},
+				Spec: rcsv1alpha1.CappSpec{
+					ConfigurationSpec: knativev1.ConfigurationSpec{},
+					ScaleMetric:       tc.scaleMetric,
+					Site:              "local-cluster",
+					RouteSpec: rcsv1alpha1.RouteSpec{
+						Hostname: "test.com",
+					},
+				},
+			}
+			g := NewWithT(t)
+			rc := DefaultMutator{}
+
+			oldCapp := capp
+			rc.handle(&capp)
+			if tc.mutated {
+				g.Expect(capp.Spec.ScaleMetric).Should(Equal(DefaultScaleMetric))
+			} else {
+				g.Expect(capp.Spec.ScaleMetric == oldCapp.Spec.ScaleMetric).Should(BeTrue())
+			}
+		})
+	}
+}

--- a/test/e2e/cappPlacement-test/00-assert.yaml
+++ b/test/e2e/cappPlacement-test/00-assert.yaml
@@ -1,0 +1,12 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120  # Timeout waiting for the state
+---
+apiVersion: rcs.dana.io/v1alpha1
+kind: Capp
+metadata:
+  name: capp-with-cluster
+  namespace: budaka
+status:
+  applicationLinks:
+    site: ocp-nikola

--- a/test/e2e/cappPlacement-test/00-deploy-capp-with-cluster.yaml
+++ b/test/e2e/cappPlacement-test/00-deploy-capp-with-cluster.yaml
@@ -1,0 +1,26 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 20
+---
+apiVersion: rcs.dana.io/v1alpha1
+kind: Capp
+metadata:
+  name: capp-with-cluster
+  namespace: budaka
+spec:
+  site: ocp-nikola
+  configurationSpec:
+    template:
+      metadata:
+        creationTimestamp: null
+      spec:
+        containers:
+          - env:
+              - name: APP_NAME
+                value: capp-with-cluster
+            image: 'sahar2339/example-python-app:v1-flask'
+            name: capp-with-cluster
+            resources: {}
+  routeSpec:
+    hostname: rbacqwegen.dev
+  scaleMetric: cpu

--- a/test/e2e/cappPlacement-test/01-assert.yaml
+++ b/test/e2e/cappPlacement-test/01-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- command: kubectl assert exist-enhanced capp --field-selector metadata.name=capp-without-site,status.applicationLinks.site!='<none>' -n budaka
+timeout: 120

--- a/test/e2e/cappPlacement-test/01-deploy-capp-without-site.yaml
+++ b/test/e2e/cappPlacement-test/01-deploy-capp-without-site.yaml
@@ -1,0 +1,25 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 20
+---
+apiVersion: rcs.dana.io/v1alpha1
+kind: Capp
+metadata:
+  name: capp-without-site
+  namespace: budaka
+spec:
+  configurationSpec:
+    template:
+      metadata:
+        creationTimestamp: null
+      spec:
+        containers:
+          - env:
+              - name: APP_NAME
+                value: capp-without-site
+            image: 'sahar2339/example-python-app:v1-flask'
+            name: capp-without-site
+            resources: {}
+  routeSpec:
+    hostname: rbacgesdn.dev
+  scaleMetric: cpu

--- a/test/e2e/cappPlacement-test/02-assert.yaml
+++ b/test/e2e/cappPlacement-test/02-assert.yaml
@@ -1,0 +1,8 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - command: ./test/e2e/cappPlacement-test/level02Script.sh
+timeout: 120
+#- command: kubectl get placement nesharim -n default -o jsonpath='{.spec.clusterSets[0]}'
+#- command: clusters=kubectl get managedclusters -l cluster.open-cluster-management.io/clusterset=$clusterset -o jsonpath='{range .items[*]}{.metadata.name}{" "}{end}' | sed 's/ /| /g'
+#- command: kubectl assert exist-enhanced capp --field-selector metadata.name=capp-with-placement,status.applicationLinks.site=~'$clusters' -n omeriko

--- a/test/e2e/cappPlacement-test/02-deploy-capp-with-placement.yaml
+++ b/test/e2e/cappPlacement-test/02-deploy-capp-with-placement.yaml
@@ -1,0 +1,26 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 40
+---
+apiVersion: rcs.dana.io/v1alpha1
+kind: Capp
+metadata:
+  name: capp-with-placement
+  namespace: budaka
+spec:
+  site: nesharim
+  configurationSpec:
+    template:
+      metadata:
+        creationTimestamp: null
+      spec:
+        containers:
+          - env:
+              - name: APP_NAME
+                value: capp-with-placement
+            image: 'sahar2339/example-python-app:v1-flask'
+            name: capp-with-placement
+            resources: {}
+  routeSpec:
+    hostname: rbacsdgesdn.dev
+  scaleMetric: cpu

--- a/test/e2e/cappPlacement-test/level02Script.sh
+++ b/test/e2e/cappPlacement-test/level02Script.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+clusterset=`kubectl get placement nesharim -n default -o jsonpath='{.spec.clusterSets[0]}'`
+echo $clusterset
+clusters=`kubectl get managedclusters -l cluster.open-cluster-management.io/clusterset=default -o jsonpath='{range .items[*]}{.metadata.name}{" "}{end}'`
+clusters_strings=$(echo $clusters | tr ' ' '|')
+# | sed 's/ /| /g'
+fixed_clusters_strings+=$clusters_strings
+
+kubectl assert exist-enhanced capp --field-selector metadata.name=capp-with-placement,status.applicationLinks.site=~$fixed_clusters_strings -n budaka

--- a/test/e2e/defaults_webhook-test/00-assert.yaml
+++ b/test/e2e/defaults_webhook-test/00-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120  # Timeout waiting for the state
+---
+apiVersion: rcs.dana.io/v1alpha1
+kind: Capp
+metadata:
+  name: capp-without-metric
+spec:
+  scaleMetric: cpu 
+status:
+  applicationLinks:
+    site: ocp-keshet

--- a/test/e2e/defaults_webhook-test/00-deploy-capp-without-metric.yaml
+++ b/test/e2e/defaults_webhook-test/00-deploy-capp-without-metric.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 20
+---
+apiVersion: rcs.dana.io/v1alpha1
+kind: Capp
+metadata:
+  name: capp-without-metric
+spec:
+  site: ocp-keshet
+  configurationSpec:
+    template:
+      metadata:
+        creationTimestamp: null
+      spec:
+        containers:
+          - env:
+              - name: APP_NAME
+                value: capp-without-metric
+            image: 'sahar2339/example-python-app:v1-flask'
+            name: capp-without-metric
+            resources: {}
+  routeSpec:
+    hostname: rbacqwegen.dev

--- a/test/e2e/defaults_webhook-test/01-assert.yaml
+++ b/test/e2e/defaults_webhook-test/01-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120  # Timeout waiting for the state
+---
+apiVersion: rcs.dana.io/v1alpha1
+kind: Capp
+metadata:
+  name: capp-with-metric
+spec:
+  scaleMetric: rps
+status:
+  applicationLinks:
+    site: ocp-keshet

--- a/test/e2e/defaults_webhook-test/01-deploy-capp-with-metric.yaml
+++ b/test/e2e/defaults_webhook-test/01-deploy-capp-with-metric.yaml
@@ -1,0 +1,25 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 20
+---
+apiVersion: rcs.dana.io/v1alpha1
+kind: Capp
+metadata:
+  name: capp-with-metric
+spec:
+  site: ocp-keshet
+  configurationSpec:
+    template:
+      metadata:
+        creationTimestamp: null
+      spec:
+        containers:
+          - env:
+              - name: APP_NAME
+                value: capp-with-metric
+            image: 'sahar2339/example-python-app:v1-flask'
+            name: capp-with-metric
+            resources: {}
+  scaleMetric: rps
+  routeSpec:
+    hostname: rbacqwegen.dev

--- a/test/e2e/example-test/00-assert.yaml
+++ b/test/e2e/example-test/00-assert.yaml
@@ -1,0 +1,12 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20  # Timeout waiting for the state
+---
+apiVersion: rcs.dana.io/v1alpha1
+kind: Capp
+metadata:
+  name: kuttl
+  namespace: omeriko
+status:
+  applicationLinks:
+    site: ocp-sdf

--- a/test/e2e/example-test/00-deploy-first-capp.yaml
+++ b/test/e2e/example-test/00-deploy-first-capp.yaml
@@ -1,0 +1,25 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 10
+---
+apiVersion: rcs.dana.io/v1alpha1
+kind: Capp
+metadata:
+  name: kuttl
+  namespace: omeriko
+spec:
+  configurationSpec:
+    template:
+      metadata:
+        creationTimestamp: null
+      spec:
+        containers:
+          - env:
+              - name: APP_NAME
+                value: kuttl
+            image: 'sahar2339/example-python-app:v1-flask'
+            name: kuttl
+            resources: {}
+  routeSpec:
+    hostname: rbacgen.dev
+  scaleMetric: cpu

--- a/test/e2e/kuttl-test.yaml
+++ b/test/e2e/kuttl-test.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+crdDir: config/crd/bases
+testDirs:
+- ./test/e2e/
+skipDelete: true


### PR DESCRIPTION
Fixes #18. Added the default webhook, which currently handles the scaleMetric field and sets cpu as a default value. Additionally, added unit testing and KuTTL test suite.