### PR TITLE
Install kubectl-assert with Makefile

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -178,7 +178,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
 .PHONY: test-e2e
-test-e2e: install-kuttl
+test-e2e: install-kuttl install-assert
 	kubectl kuttl test ./test/e2e
 
 ##@ Build
@@ -194,15 +194,25 @@ $(ENVTEST): $(LOCALBIN)
 
 KUTTL_BINARY_INSTALLATION ?= "https://github.com/kudobuilder/kuttl/releases/download/v0.15.0/kuttl_0.15.0_linux_x86_64.tar.gz"
 KUTTL_TAR_FILE_NAME ?= kuttl_0.15.0_linux_x86_64.tar.gz
-KUTTL_LOCATION ?= /usr/local/bin/kubectl-kuttl
+KUTTL_LOCATION ?= $(LOCALBIN)/kubectl-kuttl
 
 .PHONY: install-kuttl
 install-kuttl:
 	@if ! test -f "$(KUTTL_LOCATION)"; then \
 		curl -LO $(KUTTL_BINARY_INSTALLATION); \
 		tar -xvf $(KUTTL_TAR_FILE_NAME); \
-		sudo mv kubectl-kuttl /usr/local/bin/; \
+		sudo mv kubectl-kuttl $(LOCALBIN); \
 		rm -rf $(KUTTL_TAR_FILE_NAME); \
+	fi
+
+ASSERT_LOCATION ?= $(LOCALBIN)/kubectl-assert
+ASSERT_BINATY_INSTALLATION ?= "https://raw.githubusercontent.com/morningspace/kubeassert/master/kubectl-assert.sh"
+.PHONY: install-assert
+install-assert:
+	@if ! test -f "$(ASSERT_LOCATION)"; then \
+		curl -L $(ASSERT_BINATY_INSTALLATION) -o kubectl-assert; \
+		chmod +x kubectl-assert; \
+		sudo mv ./kubectl-assert $(LOCALBIN); \
 	fi
 
 .PHONY: bundle

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ KUTTL_TAR_FILE_NAME ?= kuttl_0.15.0_linux_x86_64.tar.gz
 KUTTL_LOCATION ?= $(LOCALBIN)/kubectl-kuttl
 
 .PHONY: install-kuttl
-install-kuttl:
+install-kuttl: $(KUTTL_LOCATION)
 	@if ! test -f "$(KUTTL_LOCATION)"; then \
 		curl -LO $(KUTTL_BINARY_INSTALLATION); \
 		tar -xvf $(KUTTL_TAR_FILE_NAME); \
@@ -208,7 +208,7 @@ install-kuttl:
 ASSERT_LOCATION ?= $(LOCALBIN)/kubectl-assert
 ASSERT_BINATY_INSTALLATION ?= "https://raw.githubusercontent.com/morningspace/kubeassert/master/kubectl-assert.sh"
 .PHONY: install-assert
-install-assert:
+install-assert: $(ASSERT_LOCATION)
 	@if ! test -f "$(ASSERT_LOCATION)"; then \
 		curl -L $(ASSERT_BINATY_INSTALLATION) -o kubectl-assert; \
 		chmod +x kubectl-assert; \

--- a/README.md
+++ b/README.md
@@ -1,148 +1,43 @@
-# rcs-ocm-deployer
-The `rcs-ocm-deployer` is an operator designed to deploy `knative service` workloads created on the hub to the managed cluster with the lowest load average on specific namespace.
+# KUTTL
 
-## Open Cluster Management and Knative
-This project uses the `Placement` and `ManifestWork` APIs of the Open Cluster Management (OCM) project. For more information please refer to the [OCM documentation](https://open-cluster-management.io/concepts/).
+<img src="https://kuttl.dev/images/kuttl-horizontal-logo.png" width="256">
 
-In order, please refer to the [Knative Serving documentation](https://knative.dev/docs/serving/) for more information about the `knative service` object.
+[![lint](https://github.com/kudobuilder/kuttl/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/kudobuilder/kuttl/actions)
+[![unit test](https://github.com/kudobuilder/kuttl/actions/workflows/unittest.yml/badge.svg?branch=main)](https://github.com/kudobuilder/kuttl/actions)
+[![integration-test](https://github.com/kudobuilder/kuttl/actions/workflows/integration-test.yml/badge.svg?branch=main)](https://github.com/kudobuilder/kuttl/actions)
+[![e2e](https://github.com/kudobuilder/kuttl/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/kudobuilder/kuttl/actions)
 
-## Description
-### The Annotations
-Two annotations are required in the `knative service` yaml:  
+KUbernetes Test TooL (KUTTL) provides a declarative approach to test Kubernetes Operators.
 
-- `dana.io/ocm-placement: <PLACEMENT>` - The name of the placement to decide from which manage cluster to deploy on.
-- `dana.io/ocm-managed-cluster-namespace: <MANAGED_CLUSTER_NS>` - The namespace on the managed cluster where `knative service` needs to be deployed.
-
-### The controllers
-
-1. `service placement controller`: The controller extracts the placement from the `knative serivce` annotation and adds an annotation containing the cluster where to deploy, in accordance to the `placementDesicion`.
-
-2. `service namespace controller`: The controller extracts the namespace name from the `knative serivce` annotaion and creates a `ManifestWork` in the desired `ManagedCluster` namespace, which contains the namespace with the desired name to be deployed, and adds an annotation to the service when the namespace is created.
-
-3. `service controller`: The controller extracts the namespace name and the desired cluster from the `knative serivce` annotations and creates a `ManifestWork` in the desired `ManagedCluster` namespace; the agent on the `ManagedCluster` takes care of deploying the `knative serivce` on the cluster itself.
+KUTTL is designed for testing operators, however it can declaratively test any kubernetes objects.
 
 ## Getting Started
-You’ll need a Kubernetes cluster to run against. You can use [KinD](https://sigs.k8s.io/kind) to get a local cluster for testing, or run against a remote cluster.
-**Note:** Your controller will automatically use the current context in your kubeconfig file (i.e. whatever cluster `kubectl cluster-info` shows).
 
-### Setting Up a Hub Cluster and Managed Clusters locally
-The [OCM project](https://github.com/open-cluster-management-io/OCM) contains a script that allows spinning up a `KinD`-based environment, containing of a Hub Cluster and 2 Managed Clusters.
+Please refer to the [getting started guide](https://kuttl.dev/docs/) documentation.
 
-You can clone the repository and set up the environment, provided that you have `KinD` and `docker` installed on your machine. 
+## Resources
 
-This script would create 3 clusters with the following Kubernetes contextes: 
+Initially Built under the KUDO project, we continue to use that channel for KUTTL.
 
-- `kind-hub`
-- `kind-cluster1`
-- `kind-cluster2`
+* Slack Channel: [#kudo](https://kubernetes.slack.com/archives/CG3HTFCMV)
+* Google Group: [kudobuilder@googlegroups.com](https://groups.google.com/forum/#!forum/kudobuilder)
 
-To switch between contexes, use `kubectl config set-context <CONTEXT_NAME>`
+## Community Meetings
 
-```
-$ git clone https://github.com/open-cluster-management-io/OCM
-$ bash ./OCM/solutions/setup-dev-environment/local-up.sh
-```
+We have open community meetings every 2nd and 4th Wednesday of the month at 9:00 a.m. PST. (17:00 UTC)
 
-### Installing Knative
-Follow the instructions of the Knative website to [install the Knative CLI](https://knative.dev/docs/getting-started/quickstart-install/#install-the-knative-cli), `kn`. Install Knative on the Managed Clusters:
+* Agenda and Notes: https://docs.google.com/document/d/1UqgtCMUHSsOohZYF8K7zX8WcErttuMSx7NbvksIbZgg
+* Zoom Meeting: https://d2iq.zoom.us/j/443128842
 
-```
-$ kubectl config use-context kind-cluster1
-$ kn quickstart kind --name cluster1
 
-Running Knative Quickstart using Kind
-✅ Checking dependencies...
-    Kind version is: 0.17.0
+## Community, Events, Discussion, Contribution, and Support
 
-Knative Cluster kind-cluster1 already installed.
-Delete and recreate [y/N]: N
+Learn more on how to engage with the KUDO community on the [community page](https://kudo.dev/community/).
 
-    Installation skipped
-🍿 Installing Knative Serving v1.8.0 ...
-    CRDs installed...
-    Core installed...
-    Finished installing Knative Serving
-🕸️ Installing Kourier networking layer v1.8.0 ...
-    Kourier installed...
-    Ingress patched...
-    Finished installing Kourier Networking layer
-🕸 Configuring Kourier for Kind...
-    Kourier service installed...
-    Domain DNS set up...
-    Finished configuring Kourier
-🔥 Installing Knative Eventing v1.8.0 ...
-    CRDs installed...
-    Core installed...
-    In-memory channel installed...
-    Mt-channel broker installed...
-    Example broker installed...
-    Finished installing Knative Eventing
-```
-```
-$ kubectl config use-context kind-cluster2
-$ kn quickstart kind --name cluster2
+## Contributions
 
-Running Knative Quickstart using Kind
-✅ Checking dependencies...
-    Kind version is: 0.17.0
+Please read the [contributing guide](https://github.com/kudobuilder/kuttl/blob/main/CONTRIBUTING.md) for details around:
 
-Knative Cluster kind-cluster2 already installed.
-Delete and recreate [y/N]: N
-
-    Installation skipped
-🍿 Installing Knative Serving v1.8.0 ...
-    CRDs installed...
-    Core installed...
-    Finished installing Knative Serving
-🕸️ Installing Kourier networking layer v1.8.0 ...
-    Kourier installed...
-    Ingress patched...
-    Finished installing Kourier Networking layer
-🕸 Configuring Kourier for Kind...
-    Kourier service installed...
-    Domain DNS set up...
-    Finished configuring Kourier
-🔥 Installing Knative Eventing v1.8.0 ...
-    CRDs installed...
-    Core installed...
-    In-memory channel installed...
-    Mt-channel broker installed...
-    Example broker installed...
-    Finished installing Knative Eventing
-```
-### Deploying the `rcs-ocm-deployer`
-On the hub cluster, install just the Knative Service CRD:
-
-```
-$ kubectl apply -f hack/crds/knative-serving-crds.yaml
-```
-
-Use the `Makefile` in order to deploy controllers onto the Hub cluster. You can either push the image to a remote registry, using `docker-push`, or work locally without pusing the image.
-
-When working locally:
-
-```
-$ kubectl config use-context kind-hub
-```
-```
-$ make docker-build IMG=rcs-ocm-deployer:v0.1
-$ kind load docker-image rcs-ocm-deployer:v0.1
-$ make deploy IMG=rcs-ocm-deployer:v0.1
-```
-
-## License
-
-Copyright 2022.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
+1. Code of Conduct
+1. Code Culture
+1. Details on how to contribute


### PR DESCRIPTION
Fixes #32.
With this PR, we can install kubectl-assert with install-assert entry in the Makefile.