### PR TITLE
Add e2e-test to addon status-sync

### DIFF
--- a/test/e2e/addon_status-test/00-assert.yaml
+++ b/test/e2e/addon_status-test/00-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+- command: kubectl assert exist-enhanced capp --field-selector metadata.name=capp-statuscheck,status.applicationLinks.site!='<none>' -A
+timeout: 20

--- a/test/e2e/addon_status-test/00-deploy-capp-with-status.yaml
+++ b/test/e2e/addon_status-test/00-deploy-capp-with-status.yaml
@@ -1,13 +1,12 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 40
+timeout: 20
 ---
 apiVersion: rcs.dana.io/v1alpha1
 kind: Capp
 metadata:
-  name: capp-with-placement
+  name: capp-statuscheck
 spec:
-  site: placement-1st
   configurationSpec:
     template:
       metadata:
@@ -16,10 +15,10 @@ spec:
         containers:
           - env:
               - name: APP_NAME
-                value: capp-with-placement
+                value: capp-statuscheck
             image: 'sahar2339/example-python-app:v1-flask'
-            name: capp-with-placement
+            name: capp-statuscheck
             resources: {}
   routeSpec:
-    hostname: rbacsdgesdn.dev
+    hostname: rbacgesdn.dev
   scaleMetric: cpu

--- a/test/e2e/addon_status-test/01-assert.yaml
+++ b/test/e2e/addon_status-test/01-assert.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 20  # Timeout waiting for the state
+---
+apiVersion: rcs.dana.io/v1alpha1
+kind: Capp
+metadata:
+  name: capp-statuscheck
+status:
+  knativeObjectStatus:
+    latestCreatedRevisionName: capp-statuscheck-00003

--- a/test/e2e/addon_status-test/01-deploy-capp-broken-image.yaml
+++ b/test/e2e/addon_status-test/01-deploy-capp-broken-image.yaml
@@ -1,13 +1,12 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 40
+timeout: 20
 ---
 apiVersion: rcs.dana.io/v1alpha1
 kind: Capp
 metadata:
-  name: capp-with-placement
+  name: capp-statuscheck
 spec:
-  site: placement-1st
   configurationSpec:
     template:
       metadata:
@@ -16,10 +15,11 @@ spec:
         containers:
           - env:
               - name: APP_NAME
-                value: capp-with-placement
-            image: 'sahar2339/example-python-app:v1-flask'
-            name: capp-with-placement
+                value: capp-statuscheck
+            image: 'no-img'
+            name: capp-statuscheck
             resources: {}
   routeSpec:
-    hostname: rbacsdgesdn.dev
+    hostname: rbacgesdn.dev
   scaleMetric: cpu
+

--- a/test/e2e/cappPlacement-test/00-assert.yaml
+++ b/test/e2e/cappPlacement-test/00-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 120  # Timeout waiting for the state
+timeout: 30  # Timeout waiting for the state
 ---
 apiVersion: rcs.dana.io/v1alpha1
 kind: Capp

--- a/test/e2e/cappPlacement-test/00-assert.yaml
+++ b/test/e2e/cappPlacement-test/00-assert.yaml
@@ -8,4 +8,4 @@ metadata:
   name: capp-with-cluster
 status:
   applicationLinks:
-    site: ocp-danish-cop ocp-keshet
+    site: cluster

--- a/test/e2e/cappPlacement-test/00-deploy-capp-with-cluster.yaml
+++ b/test/e2e/cappPlacement-test/00-deploy-capp-with-cluster.yaml
@@ -9,7 +9,7 @@ kind: Capp
 metadata:
   name: capp-with-cluster
 spec:
-  site: "ocp-danish-cop ocp-keshet"
+  site: cluster
   configurationSpec:
     template:
       metadata:

--- a/test/e2e/cappPlacement-test/01-assert.yaml
+++ b/test/e2e/cappPlacement-test/01-assert.yaml
@@ -2,4 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
 - command: kubectl assert exist-enhanced capp --field-selector metadata.name=capp-without-site,status.applicationLinks.site!='<none>' -A 
-timeout: 120
+timeout: 30

--- a/test/e2e/cappPlacement-test/02-assert.yaml
+++ b/test/e2e/cappPlacement-test/02-assert.yaml
@@ -2,7 +2,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
   - command: ./test/e2e/cappPlacement-test/level02Script.sh
-timeout: 120
+timeout: 30
 #- command: kubectl get placement nesharim -n default -o jsonpath='{.spec.clusterSets[0]}'
 #- command: clusters=kubectl get managedclusters -l cluster.open-cluster-management.io/clusterset=$clusterset -o jsonpath='{range .items[*]}{.metadata.name}{" "}{end}' | sed 's/ /| /g'
 #- command: kubectl assert exist-enhanced capp --field-selector metadata.name=capp-with-placement,status.applicationLinks.site=~'$clusters' -n omeriko

--- a/test/e2e/cappPlacement-test/02-deploy-capp-with-placement.yaml
+++ b/test/e2e/cappPlacement-test/02-deploy-capp-with-placement.yaml
@@ -3,14 +3,13 @@ kind: TestStep
 timeout: 30
 commands:
   - command: bash -c "export placement=$(sh ../getClusteOrPlacement.sh placement); yq e -i 'select(di == 1).spec.site = env(placement)' 02-deploy-capp-with-placement.yaml"
-
 ---
 apiVersion: rcs.dana.io/v1alpha1
 kind: Capp
 metadata:
   name: capp-with-placement
 spec:
-  site: placement-1st
+  site: placement
   configurationSpec:
     template:
       metadata:

--- a/test/e2e/cappPlacement-test/level02Script.sh
+++ b/test/e2e/cappPlacement-test/level02Script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-clusterset=`kubectl get placement placement-2nd -n ocp-kuba-gader -o jsonpath='{.spec.clusterSets[0]}'`
+clusterset=`kubectl get placement placement-1st -n default -o jsonpath='{.spec.clusterSets[0]}'`
 echo $clusterset
 clusters=`kubectl get managedclusters -l cluster.open-cluster-management.io/clusterset=$clusterset -o jsonpath='{range .items[*]}{.metadata.name}{" "}{end}'`
 clusters_strings=$(echo $clusters | tr ' ' '|')

--- a/test/e2e/cappPlacement-test/level02Script.sh
+++ b/test/e2e/cappPlacement-test/level02Script.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-clusterset=`kubectl get placement placement-1st -n default -o jsonpath='{.spec.clusterSets[0]}'`
+placement=$(kubectl get placements -A --no-headers | awk {'print $2'})
+clusterset=`kubectl get placement $placement  -n default -o jsonpath='{.spec.clusterSets[0]}'`
 echo $clusterset
 clusters=`kubectl get managedclusters -l cluster.open-cluster-management.io/clusterset=$clusterset -o jsonpath='{range .items[*]}{.metadata.name}{" "}{end}'`
 clusters_strings=$(echo $clusters | tr ' ' '|')

--- a/test/e2e/defaults_webhook-test/00-assert.yaml
+++ b/test/e2e/defaults_webhook-test/00-assert.yaml
@@ -10,4 +10,4 @@ spec:
   scaleMetric: cpu
 status:
   applicationLinks:
-    site: ocp-danish-cop ocp-keshet
+    site: cluster

--- a/test/e2e/defaults_webhook-test/00-deploy-capp-without-metric.yaml
+++ b/test/e2e/defaults_webhook-test/00-deploy-capp-without-metric.yaml
@@ -1,4 +1,4 @@
-apiVersion: kuttl.dev/v1beta1
+:apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 30
 commands:
@@ -9,7 +9,7 @@ kind: Capp
 metadata:
   name: capp-without-metric
 spec:
-  site: ocp-danish-cop ocp-keshet
+  site: cluster
   configurationSpec:
     template:
       metadata:


### PR DESCRIPTION
Added e2e-tests to addon status-sync.
Fixed placements tests to work with default placement(the tests continue to depend on the site parameter) and shorten the  tests time out.