### PR TITLE
Changed e2e tests to be dynamic without hard coded values

### DIFF
--- a/test/e2e/cappPlacement-test/00-assert.yaml
+++ b/test/e2e/cappPlacement-test/00-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 120 # Timeout waiting for the state
+timeout: 30 # Timeout waiting for the state
 ---
 apiVersion: rcs.dana.io/v1alpha1
 kind: Capp

--- a/test/e2e/cappPlacement-test/00-assert.yaml
+++ b/test/e2e/cappPlacement-test/00-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 120  # Timeout waiting for the state
+timeout: 120 # Timeout waiting for the state
 ---
 apiVersion: rcs.dana.io/v1alpha1
 kind: Capp
@@ -8,4 +8,4 @@ metadata:
   name: capp-with-cluster
 status:
   applicationLinks:
-    site: ocp-danish-cop
+    site: ocp-rcs-managed-1

--- a/test/e2e/cappPlacement-test/00-deploy-capp-with-cluster.yaml
+++ b/test/e2e/cappPlacement-test/00-deploy-capp-with-cluster.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 20
+timeout: 30
 commands:
   - command: bash -c "export cluster=$(sh ../getClusteOrPlacement.sh cluster); yq e -i 'select(di == 1).spec.site = env(cluster)' 00-deploy-capp-with-cluster.yaml; yq e -i 'select(di == 1).status.applicationLinks.site = env(cluster)' 00-assert.yaml"
 ---

--- a/test/e2e/cappPlacement-test/00-deploy-capp-with-cluster.yaml
+++ b/test/e2e/cappPlacement-test/00-deploy-capp-with-cluster.yaml
@@ -1,13 +1,15 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 20
+commands:
+  - command: bash -c "export cluster=$(sh ../getClusteOrPlacement.sh cluster); yq e -i 'select(di == 1).spec.site = env(cluster)' 00-deploy-capp-with-cluster.yaml; yq e -i 'select(di == 1).status.applicationLinks.site = env(cluster)' 00-assert.yaml"
 ---
 apiVersion: rcs.dana.io/v1alpha1
 kind: Capp
 metadata:
   name: capp-with-cluster
 spec:
-  site: ocp-danish-cop
+  site: "ocp-rcs-managed-1"
   configurationSpec:
     template:
       metadata:

--- a/test/e2e/cappPlacement-test/01-assert.yaml
+++ b/test/e2e/cappPlacement-test/01-assert.yaml
@@ -2,4 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
 - command: kubectl assert exist-enhanced capp --field-selector metadata.name=capp-without-site,status.applicationLinks.site!='<none>' -A 
-timeout: 120
+timeout: 30

--- a/test/e2e/cappPlacement-test/01-deploy-capp-without-site.yaml
+++ b/test/e2e/cappPlacement-test/01-deploy-capp-without-site.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 20
+timeout: 30
 ---
 apiVersion: rcs.dana.io/v1alpha1
 kind: Capp

--- a/test/e2e/cappPlacement-test/02-assert.yaml
+++ b/test/e2e/cappPlacement-test/02-assert.yaml
@@ -2,4 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
   - command: ./test/e2e/cappPlacement-test/level02Script.sh
-timeout: 120
+timeout: 30

--- a/test/e2e/cappPlacement-test/02-assert.yaml
+++ b/test/e2e/cappPlacement-test/02-assert.yaml
@@ -3,6 +3,3 @@ kind: TestAssert
 commands:
   - command: ./test/e2e/cappPlacement-test/level02Script.sh
 timeout: 120
-#- command: kubectl get placement nesharim -n default -o jsonpath='{.spec.clusterSets[0]}'
-#- command: clusters=kubectl get managedclusters -l cluster.open-cluster-management.io/clusterset=$clusterset -o jsonpath='{range .items[*]}{.metadata.name}{" "}{end}' | sed 's/ /| /g'
-#- command: kubectl assert exist-enhanced capp --field-selector metadata.name=capp-with-placement,status.applicationLinks.site=~'$clusters' -n omeriko

--- a/test/e2e/cappPlacement-test/02-deploy-capp-with-placement.yaml
+++ b/test/e2e/cappPlacement-test/02-deploy-capp-with-placement.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 40
+timeout: 30
 commands:
   - command: bash -c "export placement=$(sh ../getClusteOrPlacement.sh placement); yq e -i 'select(di == 1).spec.site = env(placement)' 02-deploy-capp-with-placement.yaml"
 

--- a/test/e2e/cappPlacement-test/02-deploy-capp-with-placement.yaml
+++ b/test/e2e/cappPlacement-test/02-deploy-capp-with-placement.yaml
@@ -1,6 +1,9 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 40
+commands:
+  - command: bash -c "export placement=$(sh ../getClusteOrPlacement.sh placement); yq e -i 'select(di == 1).spec.site = env(placement)' 02-deploy-capp-with-placement.yaml"
+
 ---
 apiVersion: rcs.dana.io/v1alpha1
 kind: Capp

--- a/test/e2e/defaults_webhook-test/00-assert.yaml
+++ b/test/e2e/defaults_webhook-test/00-assert.yaml
@@ -1,13 +1,13 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 120  # Timeout waiting for the state
+timeout: 20 # Timeout waiting for the state
 ---
 apiVersion: rcs.dana.io/v1alpha1
 kind: Capp
 metadata:
   name: capp-without-metric
 spec:
-  scaleMetric: cpu 
+  scaleMetric: cpu
 status:
   applicationLinks:
-    site: ocp-danish-cop
+    site: ocp-rcs-managed-1

--- a/test/e2e/defaults_webhook-test/00-assert.yaml
+++ b/test/e2e/defaults_webhook-test/00-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 20 # Timeout waiting for the state
+timeout: 30 # Timeout waiting for the state
 ---
 apiVersion: rcs.dana.io/v1alpha1
 kind: Capp

--- a/test/e2e/defaults_webhook-test/00-deploy-capp-without-metric.yaml
+++ b/test/e2e/defaults_webhook-test/00-deploy-capp-without-metric.yaml
@@ -1,13 +1,15 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 timeout: 20
+commands:
+  - command: bash -c "export cluster=$(sh ../getClusteOrPlacement.sh cluster); yq e -i 'select(di == 1).spec.site = env(cluster)'  00-deploy-capp-without-metric.yaml; yq e -i 'select(di == 1).status.applicationLinks.site = env(cluster)' 00-assert.yaml";
 ---
 apiVersion: rcs.dana.io/v1alpha1
 kind: Capp
 metadata:
   name: capp-without-metric
 spec:
-  site: ocp-danish-cop
+  site: ocp-rcs-managed-1
   configurationSpec:
     template:
       metadata:

--- a/test/e2e/defaults_webhook-test/00-deploy-capp-without-metric.yaml
+++ b/test/e2e/defaults_webhook-test/00-deploy-capp-without-metric.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 20
+timeout: 30
 commands:
   - command: bash -c "export cluster=$(sh ../getClusteOrPlacement.sh cluster); yq e -i 'select(di == 1).spec.site = env(cluster)'  00-deploy-capp-without-metric.yaml; yq e -i 'select(di == 1).status.applicationLinks.site = env(cluster)' 00-assert.yaml";
 ---

--- a/test/e2e/defaults_webhook-test/01-assert.yaml
+++ b/test/e2e/defaults_webhook-test/01-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 120  # Timeout waiting for the state
+timeout: 30  # Timeout waiting for the state
 ---
 apiVersion: rcs.dana.io/v1alpha1
 kind: Capp

--- a/test/e2e/defaults_webhook-test/01-assert.yaml
+++ b/test/e2e/defaults_webhook-test/01-assert.yaml
@@ -8,7 +8,4 @@ metadata:
   name: capp-with-metric
 spec:
   scaleMetric: rps
-status:
-  applicationLinks:
-    site: ocp-danish-cop
 

--- a/test/e2e/defaults_webhook-test/01-deploy-capp-with-metric.yaml
+++ b/test/e2e/defaults_webhook-test/01-deploy-capp-with-metric.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 20
+timeout: 30
 ---
 apiVersion: rcs.dana.io/v1alpha1
 kind: Capp

--- a/test/e2e/defaults_webhook-test/01-deploy-capp-with-metric.yaml
+++ b/test/e2e/defaults_webhook-test/01-deploy-capp-with-metric.yaml
@@ -7,7 +7,6 @@ kind: Capp
 metadata:
   name: capp-with-metric
 spec:
-  site: ocp-danish-cop
   configurationSpec:
     template:
       metadata:

--- a/test/e2e/getClusteOrPlacement.sh
+++ b/test/e2e/getClusteOrPlacement.sh
@@ -1,0 +1,14 @@
+resource=$1
+
+placement=$(kubectl get placements -A --no-headers | awk {'print $2'})
+placementNS=$(kubectl get placements -A --no-headers | awk {'print $1'})
+clusterset=$(kubectl get placement $placement -n $placementNS -o jsonpath='{.spec.clusterSets[0]}')
+cluster=$(kubectl get managedclusters -l cluster.open-cluster-management.io/clusterset=$clusterset  --no-headers | awk {'print $1'})
+
+if [ $resource = "placement" ]
+then
+    echo $placement
+elif [ $resource = "cluster" ]
+then
+    echo $cluster
+fi


### PR DESCRIPTION
Now the e2e tests use `kubectl` commands to fetch the cluster's resources, without hard coded clusters or placements