### PR TITLE
Fix controller deployment by adding env vars to config.

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -57,6 +57,11 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
+        env:
+            - name: PLACEMENTS
+              value: placement-1st
+            - name: PLACEMENTS_NAMESPACE
+              value: default
         # TODO(user): Configure the resources accordingly based on the project requirements.
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:


### PR DESCRIPTION
Fixes #31.
With this PR, the controller deployment has two default environments variables that the `main.go` expects.