### PR TITLE
Add tls secret to Capp spec.

### DIFF
--- a/internals/utils/volumes.go
+++ b/internals/utils/volumes.go
@@ -97,5 +97,7 @@ func GetResourceVolumesFromContainerSpec(capp rcsv1alpha1.Capp, ctx context.Cont
 		secrets = append(secrets, secret.Name)
 	}
 
+	secrets = append(secrets, capp.Spec.RouteSpec.TlsSecret)
+
 	return configMaps, secrets
 }

--- a/internals/webhooks/capp_validation_utils.go
+++ b/internals/webhooks/capp_validation_utils.go
@@ -70,3 +70,17 @@ func validateDomainName(domainname string) (errs *apis.FieldError) {
 	}
 	return errs
 }
+
+// validateTlsFields checks if the fields of the tls feature in the capp spec is written correctly.
+// It takes a rcsv1alpha1.Capp object and returns aggregated error if the any of the validations falied.
+func validateTlsFields(capp rcsv1alpha1.Capp) (errs *apis.FieldError) {
+	if capp.Spec.RouteSpec.TlsEnabled && capp.Spec.RouteSpec.TlsSecret == nil{
+		errs = errs.Also(apis.ErrGeneric(fmt.Sprintf(
+					"it's forbidden to set '.spec.routeSpec.tlsEnabled' to 'true' without specifying a secret name in the '.spec.routeSpec.tlsSecret' field")))
+	}else if !capp.Spec.RouteSpec.TlsEnabled && capp.Spec.RouteSpec.TlsSecret != nil{
+		errs = errs.Also(apis.ErrGeneric(fmt.Sprintf(
+			"it's forbidden to set '.spec.routeSpec.tlsEnabled' to 'false' and specifying a secret name in the '.spec.routeSpec.tlsSecret' field")))
+	}
+
+	return errs
+}

--- a/internals/webhooks/capp_webhook.go
+++ b/internals/webhooks/capp_webhook.go
@@ -45,5 +45,8 @@ func (c *CappValidator) handle(ctx context.Context, req admission.Request, capp 
 	if errs := validateDomainName(capp.Spec.RouteSpec.Hostname); errs != nil {
 		return admission.Denied(errs.Error())
 	}
+	if errs := validateTlsFields(capp); errs != nil {
+		return admission.Denied(errs.Error())
+	}
 	return admission.Allowed("")
 }


### PR DESCRIPTION
Fixes #60.
With this PR, We can add the tls secret to the capp.spec, so the secret will be copied to the managed cluster for the https feature. Moreover, this feature is validated by a webhook.