### PR TITLE
Add LogSpec Validation to Capp validation webhook

### DIFF
--- a/internals/webhooks/capp_validation_utils.go
+++ b/internals/webhooks/capp_validation_utils.go
@@ -19,7 +19,7 @@ import (
 // isSiteValid checks if the specified site cluster name is valid or not.
 // It takes a rcsv1alpha1.Capp object, a list of placements, a Kubernetes client.Client, and a context.Context.
 // The function returns a boolean value based on the validity of the specified site cluster name.
-func isSiteVaild(capp rcsv1alpha1.Capp, placements []string, r client.Client, ctx context.Context) bool {
+func isSiteValid(capp rcsv1alpha1.Capp, placements []string, r client.Client, ctx context.Context) bool {
 	if capp.Spec.Site == "" {
 		return true
 	}
@@ -32,7 +32,7 @@ func isSiteVaild(capp rcsv1alpha1.Capp, placements []string, r client.Client, ct
 // and returns the list of cluster names as a slice of strings.
 // If there is an error while retrieving the list of managed clusters, the function returns an error.
 func getManagedClusters(r client.Client, ctx context.Context) ([]string, error) {
-	clusterNames := []string{}
+	var clusterNames []string
 	clusters := clusterv1.ManagedClusterList{}
 	if err := r.List(ctx, &clusters); err != nil {
 		return clusterNames, err
@@ -75,4 +75,47 @@ func validateTlsFields(capp rcsv1alpha1.Capp) (errs *apis.FieldError) {
 	}
 
 	return errs
+}
+
+// validateLogSpec checks if the LogSpec is valid based on the Type field.
+func validateLogSpec(logSpec rcsv1alpha1.LogSpec) *apis.FieldError {
+	requiredFields := map[string][]string{
+		"elastic": {"Host", "Index", "UserName", "PasswordSecretName"},
+		"splunk":  {"Host", "Index", "HecTokenSecretName"},
+	}
+	required, exists := requiredFields[logSpec.Type]
+	if !exists {
+		validTypes := make([]string, 0, len(requiredFields))
+		for validType := range requiredFields {
+			validTypes = append(validTypes, validType)
+		}
+		return apis.ErrGeneric(
+			fmt.Sprintf("Invalid LogSpec Type: %q. Valid types are: %q", logSpec.Type, strings.Join(validTypes, ", ")),
+			"logSpec.Type")
+	}
+	missingFields := findMissingFields(logSpec, required)
+	if len(missingFields) > 0 {
+		return apis.ErrGeneric(
+			fmt.Sprintf("%s log configuration is missing required fields: %q", logSpec.Type, strings.Join(missingFields, ", ")),
+			"logSpec")
+	}
+	return nil
+}
+
+// findMissingFields checks for missing fields in LogSpec.
+func findMissingFields(logSpec rcsv1alpha1.LogSpec, required []string) []string {
+	var missingFields []string
+	fieldValues := map[string]string{
+		"Host":               logSpec.Host,
+		"Index":              logSpec.Index,
+		"UserName":           logSpec.UserName,
+		"PasswordSecretName": logSpec.PasswordSecretName,
+		"HecTokenSecretName": logSpec.HecTokenSecretName,
+	}
+	for _, reqField := range required {
+		if value, ok := fieldValues[reqField]; !ok || value == "" {
+			missingFields = append(missingFields, reqField)
+		}
+	}
+	return missingFields
 }

--- a/internals/webhooks/capp_webhook.go
+++ b/internals/webhooks/capp_webhook.go
@@ -54,7 +54,7 @@ func (c *CappValidator) handle(ctx context.Context, capp rcsv1alpha1.Capp) admis
 		return admission.Denied("Failed to fetch RCSConfig")
 	}
 	placements := config.Spec.Placements
-	if !isSiteVaild(capp, placements, c.Client, ctx) {
+	if !isSiteValid(capp, placements, c.Client, ctx) {
 		return admission.Denied(fmt.Sprintf("this site %s is unsupported. Site field accepts either cluster name or placement name", capp.Spec.Site))
 	}
 	if errs := validateDomainName(capp.Spec.RouteSpec.Hostname); errs != nil {
@@ -62,6 +62,11 @@ func (c *CappValidator) handle(ctx context.Context, capp rcsv1alpha1.Capp) admis
 	}
 	if errs := validateTlsFields(capp); errs != nil {
 		return admission.Denied(errs.Error())
+	}
+	if capp.Spec.LogSpec != (rcsv1alpha1.LogSpec{}) {
+		if errs := validateLogSpec(capp.Spec.LogSpec); errs != nil {
+			return admission.Denied(errs.Error())
+		}
 	}
 	return admission.Allowed("")
 }

--- a/test/e2e_tests/validating_webhook.go
+++ b/test/e2e_tests/validating_webhook.go
@@ -9,9 +9,14 @@ import (
 )
 
 const (
-	UnsupportedCluster  = "my-cluster"
-	UnsupportedSite     = "my-site"
-	UnsupportedHostname = "...aaa.a...."
+	UnsupportedCluster      = "my-cluster"
+	UnsupportedSite         = "my-site"
+	UnsupportedHostname     = "...aaa.a...."
+	UnsupportedLogType      = "laber"
+	SplunkLogType           = "splunk"
+	SplunkHostExample       = "74.234.208.141"
+	MainIndex               = "main"
+	SplunkSecretNameExample = "splunk-single-standalone-secrets"
 )
 
 var _ = Describe("Validate the validating webhook", func() {
@@ -32,5 +37,27 @@ var _ = Describe("Validate the validating webhook", func() {
 		baseCapp := mock.CreateBaseCapp()
 		baseCapp.Spec.RouteSpec.Hostname = UnsupportedHostname
 		Expect(k8sClient.Create(context.Background(), baseCapp)).ShouldNot(Succeed())
+	})
+
+	It("Should deny the use of an invalid log type", func() {
+		baseCapp := mock.CreateBaseCapp()
+		baseCapp.Spec.LogSpec.Type = UnsupportedLogType
+		Expect(k8sClient.Create(context.Background(), baseCapp)).ShouldNot(Succeed())
+	})
+
+	It("Should deny the use of an incomplete log spec", func() {
+		baseCapp := mock.CreateBaseCapp()
+		baseCapp.Spec.LogSpec.Type = SplunkLogType
+		baseCapp.Spec.LogSpec.Host = SplunkHostExample
+		Expect(k8sClient.Create(context.Background(), baseCapp)).ShouldNot(Succeed())
+	})
+
+	It("Should allow the use of a complete and supported log spec", func() {
+		baseCapp := mock.CreateBaseCapp()
+		baseCapp.Spec.LogSpec.Type = SplunkLogType
+		baseCapp.Spec.LogSpec.Host = SplunkHostExample
+		baseCapp.Spec.LogSpec.Index = MainIndex
+		baseCapp.Spec.LogSpec.HecTokenSecretName = SplunkSecretNameExample
+		Expect(k8sClient.Create(context.Background(), baseCapp)).Should(Succeed())
 	})
 })


### PR DESCRIPTION
Prior to this change, there was no validation for the LogSpec field. This allowed users to create Capps with LogSpec configurations that were incomplete or incorrect.

This commit introduces robust validation for the LogSpec field, ensuring that users provide valid and complete configuration details based on the LogSpec Type selected. Specifically:
- When LogSpec Type is set to 'elastic,' it is now mandatory to provide values for Host, Index, UserName, and PasswordSecretName.
- When LogSpec Type is set to 'splunk,' it is now mandatory to provide values for Host, Index, and HecTokenSecretName.

In case users try to create Capps with incomplete or incorrect LogSpec settings, they will now receive clear error messages guiding them to provide the necessary LogSpec details.