### PR TITLE
bumped kube-rbac-proxy version

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,12 +15,12 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
         args:
-        - "--secure-listen-address=0.0.0.0:8443"
-        - "--upstream=http://127.0.0.1:8080/"
-        - "--logtostderr=true"
-        - "--v=0"
+          - "--secure-listen-address=0.0.0.0:8443"
+          - "--upstream=http://127.0.0.1:8080/"
+          - "--logtostderr=true"
+          - "--v=0"
         ports:
         - containerPort: 8443
           protocol: TCP

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -57,11 +57,6 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-        env:
-            - name: PLACEMENTS
-              value: placement-1st
-            - name: PLACEMENTS_NAMESPACE
-              value: default
         # TODO(user): Configure the resources accordingly based on the project requirements.
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:


### PR DESCRIPTION
With this PR, the version of the kube-rbac-proxy has been bumped to v0.15.0 and redundant env vars have been deleted