### PR TITLE
add support for copying secrets from valueFrom fields

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: controller
+  newTag: latest

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create

--- a/internal/placement/adapters/placement_test.go
+++ b/internal/placement/adapters/placement_test.go
@@ -1,11 +1,10 @@
-package unitTests
+package adapters
 
 import (
 	"context"
 	"testing"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
-	"github.com/dana-team/rcs-ocm-deployer/internal/placement/adapters"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -31,7 +30,7 @@ func TestGetPlacementDecisionList(t *testing.T) {
 	fakeClient := newFakeClient()
 
 	// Call GetPlacementDecisionList with the test Capp, context, fake client, and placementRef
-	placementDecisions, err := adapters.GetPlacementDecisionList(context.Background(), "placement-ref", "test-namespace", fakeClient)
+	placementDecisions, err := GetPlacementDecisionList(context.Background(), "placement-ref", "test-namespace", fakeClient)
 
 	// Assert that there are no errors
 	assert.NoError(t, err)
@@ -61,7 +60,7 @@ func TestGetDecisionClusterName(t *testing.T) {
 
 	// Create a fake logger
 	// Call GetDecisionClusterName with the test PlacementDecisionList and fake logger
-	clusterName := adapters.GetDecisionClusterName(placementDecisions, logr.Discard())
+	clusterName := GetDecisionClusterName(placementDecisions, logr.Discard())
 
 	// Assert that the returned clusterName is "cluster-1"
 	assert.Equal(t, "cluster-1", clusterName)

--- a/internal/sync/adapters/manifestwork.go
+++ b/internal/sync/adapters/manifestwork.go
@@ -15,9 +15,9 @@ import (
 )
 
 const (
-	NamespaceManifestWorkPrefix = "mw-create-"
-	CappNameKey                 = "rcs.dana.io/capp-name"
-	CappNamespaceKey            = "rcs.dana.io/capp-namespace"
+	namespaceManifestWorkPrefix = "mw-create-"
+	cappNameKey                 = "rcs.dana.io/capp-name"
+	cappNamespaceKey            = "rcs.dana.io/capp-namespace"
 )
 
 // GenerateManifestWorkGeneric generates a new Kubernetes manifest work object
@@ -41,7 +41,7 @@ func GenerateManifestWorkGeneric(name string, namespace string, manifests []work
 
 // GenerateMWName returns a manifestWork name combining NamespaceManifestWorkPrefix, capp namespace and name.
 func GenerateMWName(capp cappv1alpha1.Capp) string {
-	return NamespaceManifestWorkPrefix + capp.Namespace + "-" + capp.Name
+	return namespaceManifestWorkPrefix + capp.Namespace + "-" + capp.Name
 }
 
 // CreateManifestWork uses the Kubernetes client to create a ManifestWork resource
@@ -63,6 +63,6 @@ func CreateManifestWork(capp cappv1alpha1.Capp, managedClusterName string, logge
 // work object with the name and namespace of the specified Capp object.
 func SetManifestWorkCappAnnotations(mw workv1.ManifestWork, capp cappv1alpha1.Capp) {
 	mw.ObjectMeta.Annotations = make(map[string]string)
-	mw.Annotations[CappNameKey] = capp.Name
-	mw.Annotations[CappNamespaceKey] = capp.Namespace
+	mw.Annotations[cappNameKey] = capp.Name
+	mw.Annotations[cappNamespaceKey] = capp.Namespace
 }

--- a/internal/sync/controller/sync_controller.go
+++ b/internal/sync/controller/sync_controller.go
@@ -38,6 +38,7 @@ type SyncReconciler struct {
 //+kubebuilder:rbac:groups="rcs.dana.io",resources=rcsconfigs,verbs=get;list;watch
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 func (r *SyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx).WithValues("CappName", req.Name, "CappNamespace", req.Namespace)

--- a/test/e2e_tests/helper.go
+++ b/test/e2e_tests/helper.go
@@ -1,0 +1,44 @@
+package e2e_tests
+
+import (
+	"k8s.io/client-go/rest"
+
+	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
+	loggingv1beta1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+	networkingv1 "github.com/openshift/api/network/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	knativev1 "knative.dev/serving/pkg/apis/serving/v1"
+	knativev1alphav1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
+	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
+	workv1 "open-cluster-management.io/api/work/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	k8sClient client.Client
+	cfg       *rest.Config
+)
+
+func newScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	_ = cappv1alpha1.AddToScheme(s)
+	_ = loggingv1beta1.AddToScheme(s)
+	_ = knativev1alphav1.AddToScheme(s)
+	_ = knativev1.AddToScheme(s)
+	_ = networkingv1.Install(s)
+	_ = routev1.Install(s)
+	_ = clusterv1.Install(s)
+	_ = clusterv1alpha1.Install(s)
+	_ = clusterv1beta1.Install(s)
+	_ = clusterv1beta2.Install(s)
+	_ = workv1.Install(s)
+	_ = scheme.AddToScheme(s)
+	return s
+}

--- a/test/e2e_tests/mocks/base.go
+++ b/test/e2e_tests/mocks/base.go
@@ -9,20 +9,23 @@ import (
 )
 
 var (
-	NSName          = "capp-e2e-tests"
-	CappSecretName  = "capp-secret"
-	CappAdmin       = "capp-admin"
-	CappName        = "capp-default-test"
-	CappBaseImage   = "ghcr.io/knative/autoscale-go:latest"
-	SecretDataKey   = "password"
-	SecretDataValue = "password"
+	NSName            = "capp-e2e-tests"
+	cappSecretName    = "capp-secret"
+	cappConfigMapName = "capp-config"
+	cappAdmin         = "capp-admin"
+	cappName          = "capp-default-test"
+	cappBaseImage     = "ghcr.io/knative/autoscale-go:latest"
+	DataKey           = "password"
+	DataValue         = "password"
+	KindConfigMap     = "ConfigMap"
+	KindSecret        = "Secret"
 )
 
 // CreateBaseCapp is responsible for making the most lean version of Capp, so we can manipulate it in the tests.
 func CreateBaseCapp() *cappv1alpha1.Capp {
 	return &cappv1alpha1.Capp{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      CappName,
+			Name:      cappName,
 			Namespace: NSName,
 		},
 		Spec: cappv1alpha1.CappSpec{
@@ -35,11 +38,11 @@ func CreateBaseCapp() *cappv1alpha1.Capp {
 									Env: []corev1.EnvVar{
 										{
 											Name:  "APP_NAME",
-											Value: CappName,
+											Value: cappName,
 										},
 									},
-									Image: CappBaseImage,
-									Name:  CappName,
+									Image: cappBaseImage,
+									Name:  cappName,
 								},
 							},
 						},
@@ -50,15 +53,36 @@ func CreateBaseCapp() *cappv1alpha1.Capp {
 	}
 }
 
-// CreateSecret creates a simple secret for our tests' use.
+// CreateSecret creates a basic secret.
 func CreateSecret() *corev1.Secret {
 	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       KindSecret,
+			APIVersion: "v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      CappSecretName,
+			Name:      cappSecretName,
 			Namespace: NSName,
 		},
 		Data: map[string][]byte{
-			SecretDataKey: []byte(SecretDataValue),
+			DataKey: []byte(DataValue),
+		},
+	}
+}
+
+// CreateConfigMap creates a basic configMap.
+func CreateConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       KindConfigMap,
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cappConfigMapName,
+			Namespace: NSName,
+		},
+		BinaryData: map[string][]byte{
+			DataKey: []byte(DataValue),
 		},
 	}
 }
@@ -79,13 +103,13 @@ func CreateCappRole() *rbacv1.Role {
 		},
 	}
 
-	return CreateRole(CappAdmin+"-role", rules)
+	return CreateRole(cappAdmin+"-role", rules)
 }
 
 // CreateCappRoleBinding creates a binding for the pod reader role.
 func CreateCappRoleBinding() *rbacv1.RoleBinding {
 	roleRef := rbacv1.RoleRef{
-		Name:     CappAdmin + "-role",
+		Name:     cappAdmin + "-role",
 		Kind:     "Role",
 		APIGroup: "rbac.authorization.k8s.io",
 	}
@@ -93,12 +117,12 @@ func CreateCappRoleBinding() *rbacv1.RoleBinding {
 	subjects := []rbacv1.Subject{
 		{
 			Kind:     "User",
-			Name:     CappAdmin,
+			Name:     cappAdmin,
 			APIGroup: "rbac.authorization.k8s.io",
 		},
 	}
 
-	return CreateRoleBinding(CappAdmin+"-role-binding", roleRef, subjects)
+	return CreateRoleBinding(cappAdmin+"-role-binding", roleRef, subjects)
 }
 
 // CreateRole creates a role with the specified name and rules.

--- a/test/e2e_tests/sync.go
+++ b/test/e2e_tests/sync.go
@@ -15,10 +15,37 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const NamespaceManifestWorkPrefix = "mw-create-"
+const (
+	namespaceManifestWorkPrefix = "mw-create-"
+	envVarName                  = "E2E-TEST"
+)
+
+// verifySecretOrConfigMapCopy makes sure a Secret or a ConfigMap is eventually copied to the ManifestWork,
+// by creating a Capp with the needed configuration and getting the created ManifestWork resource.
+func verifySecretOrConfigMapCopy(baseCapp *cappv1alpha1.Capp, name, namespace, kind string) {
+	desiredCapp := utilst.CreateCapp(k8sClient, baseCapp)
+
+	assertionCapp := utilst.GetCappWithPlacementAnnotation(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
+	mwNamespace := assertionCapp.Annotations[testconsts.AnnotationKeyHasPlacement]
+
+	manifestWork := &workv1.ManifestWork{}
+
+	resourceFactory := map[string]client.Object{
+		mock.KindSecret:    &corev1.Secret{},
+		mock.KindConfigMap: &corev1.ConfigMap{},
+	}
+
+	Eventually(func() bool {
+		mwName := namespaceManifestWorkPrefix + assertionCapp.Namespace + "-" + assertionCapp.Name
+		_ = k8sClient.Get(context.Background(), client.ObjectKey{Name: mwName, Namespace: mwNamespace}, manifestWork)
+		object, err := utilst.IsObjInManifestWork(k8sClient, *manifestWork, name, namespace, resourceFactory[kind], kind)
+		Expect(err).Should(BeNil())
+		return object
+	}, testconsts.Timeout, testconsts.Interval).Should(BeTrue())
+}
 
 var _ = Describe("Validate the placement sync controller", func() {
-	It("Should add a cleanup finalizer to created capp", func() {
+	It("Should add a cleanup finalizer to created Capp", func() {
 		baseCapp := mock.CreateBaseCapp()
 		desiredCapp := utilst.CreateCapp(k8sClient, baseCapp)
 
@@ -33,19 +60,11 @@ var _ = Describe("Validate the placement sync controller", func() {
 		}, testconsts.Timeout, testconsts.Interval).Should(BeTrue(), "Should fetch capp.")
 	})
 
-	It("Should delete all capp dependent resources when capp is deleted", func() {
+	It("Should delete all Capp dependent resources when Capp is deleted", func() {
 		baseCapp := mock.CreateBaseCapp()
 		desiredCapp := utilst.CreateCapp(k8sClient, baseCapp)
 
-		By("Checks unique creation of Capp")
-		assertionCapp := utilst.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
-		Expect(assertionCapp.Name).ShouldNot(Equal(baseCapp.Name))
-
-		By("Waiting for placement to be set on Capp")
-		Eventually(func() string {
-			assertionCapp = utilst.GetCapp(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
-			return assertionCapp.Annotations[testconsts.AnnotationKeyHasPlacement]
-		}, testconsts.Timeout, testconsts.Interval).ShouldNot(Equal(""), "Should fetch capp.")
+		assertionCapp := utilst.GetCappWithPlacementAnnotation(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
 		mwNamespace := assertionCapp.Annotations[testconsts.AnnotationKeyHasPlacement]
 
 		By("Deletes capp")
@@ -54,87 +73,138 @@ var _ = Describe("Validate the placement sync controller", func() {
 		By("Checks if ManifestWork was deleted")
 		manifestWork := &workv1.ManifestWork{}
 		Eventually(func() bool {
-			mwName := NamespaceManifestWorkPrefix + assertionCapp.Namespace + "-" + assertionCapp.Name
+			mwName := namespaceManifestWorkPrefix + assertionCapp.Namespace + "-" + assertionCapp.Name
 			Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: mwName, Namespace: mwNamespace}, manifestWork)).Should(Succeed())
 			return utilst.DoesResourceExist(k8sClient, manifestWork)
 		}, testconsts.Timeout, testconsts.Interval).ShouldNot(BeFalse())
 	})
 
-	It("Should copy the secret from volumes to ManifestWork ", func() {
+	It("Should copy the secret from volumes to ManifestWork", func() {
 		baseSecret := mock.CreateSecret()
 		secret := utilst.CreateSecret(k8sClient, baseSecret)
 		baseCapp := mock.CreateBaseCapp()
-		baseCapp.Spec.ConfigurationSpec.Template.Spec.Volumes = append(baseCapp.Spec.ConfigurationSpec.Template.Spec.Volumes, corev1.Volume{
-			Name: secret.Name,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: secret.Name,
+		baseCapp.Spec.ConfigurationSpec.Template.Spec.Volumes = append(
+			baseCapp.Spec.ConfigurationSpec.Template.Spec.Volumes,
+			corev1.Volume{
+				Name: secret.Name,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: secret.Name,
+					},
 				},
-			},
-		})
+			})
 
-		baseCapp.Spec.ConfigurationSpec.Template.Spec.Containers[0].VolumeMounts = append(baseCapp.Spec.ConfigurationSpec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
-			Name:      secret.Name,
-			MountPath: "/test/mount",
-		})
+		baseCapp.Spec.ConfigurationSpec.Template.Spec.Containers[0].VolumeMounts = append(
+			baseCapp.Spec.ConfigurationSpec.Template.Spec.Containers[0].VolumeMounts,
+			corev1.VolumeMount{
+				Name:      secret.Name,
+				MountPath: "/test/mount",
+			})
 
-		desiredCapp := utilst.CreateCapp(k8sClient, baseCapp)
-
-		By("Checks unique creation of Capp")
-		assertionCapp := utilst.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
-		Expect(assertionCapp.Name).ShouldNot(Equal(baseCapp.Name))
-
-		By("Waiting for placement to be set on Capp")
-		Eventually(func() string {
-			assertionCapp = utilst.GetCapp(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
-			return assertionCapp.Annotations[testconsts.AnnotationKeyHasPlacement]
-		}, testconsts.Timeout, testconsts.Interval).ShouldNot(Equal(""), "Should fetch capp.")
-		mwNamespace := assertionCapp.Annotations[testconsts.AnnotationKeyHasPlacement]
-
-		By("Checks ManifestWork was synced with secret")
-		manifestWork := &workv1.ManifestWork{}
-		Eventually(func() bool {
-			mwName := NamespaceManifestWorkPrefix + assertionCapp.Namespace + "-" + assertionCapp.Name
-			_ = k8sClient.Get(context.Background(), client.ObjectKey{Name: mwName, Namespace: mwNamespace}, manifestWork)
-			secret, err := utilst.IsObjInManifestWork(k8sClient, *manifestWork, secret.Name, secret.Namespace, &corev1.Secret{}, "Secret")
-			Expect(err).Should(BeNil())
-			return secret
-		}, testconsts.Timeout, testconsts.Interval).Should(BeTrue())
+		verifySecretOrConfigMapCopy(baseCapp, secret.Name, secret.Namespace, baseSecret.TypeMeta.Kind)
 	})
 
-	It("Should copy the secret from environment variables to ManifestWork ", func() {
+	It("Should copy the secret from environment variables to ManifestWork (envFrom)", func() {
 		baseSecret := mock.CreateSecret()
 		secret := utilst.CreateSecret(k8sClient, baseSecret)
 		baseCapp := mock.CreateBaseCapp()
-		baseCapp.Spec.ConfigurationSpec.Template.Spec.Containers[0].EnvFrom = append(baseCapp.Spec.ConfigurationSpec.Template.Spec.Containers[0].EnvFrom, corev1.EnvFromSource{
-			SecretRef: &corev1.SecretEnvSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: secret.Name,
+		baseCapp.Spec.ConfigurationSpec.Template.Spec.Containers[0].EnvFrom = append(
+			baseCapp.Spec.ConfigurationSpec.Template.Spec.Containers[0].EnvFrom,
+			corev1.EnvFromSource{
+				SecretRef: &corev1.SecretEnvSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: secret.Name,
+					},
 				},
-			},
-		})
-		desiredCapp := utilst.CreateCapp(k8sClient, baseCapp)
+			})
 
-		By("Checks unique creation of Capp")
-		assertionCapp := utilst.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
-		Expect(assertionCapp.Name).ShouldNot(Equal(baseCapp.Name))
+		verifySecretOrConfigMapCopy(baseCapp, secret.Name, secret.Namespace, baseSecret.TypeMeta.Kind)
+	})
 
-		By("Waiting for placement to be set on Capp")
-		Eventually(func() string {
-			assertionCapp = utilst.GetCapp(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
-			return assertionCapp.Annotations[testconsts.AnnotationKeyHasPlacement]
-		}, testconsts.Timeout, testconsts.Interval).ShouldNot(Equal(""), "Should fetch capp.")
-		mwNamespace := assertionCapp.Annotations[testconsts.AnnotationKeyHasPlacement]
+	It("Should copy the secret from environment variables to ManifestWork (valueFrom)", func() {
+		baseSecret := mock.CreateSecret()
+		secret := utilst.CreateSecret(k8sClient, baseSecret)
+		baseCapp := mock.CreateBaseCapp()
+		baseCapp.Spec.ConfigurationSpec.Template.Spec.Containers[0].Env = append(
+			baseCapp.Spec.ConfigurationSpec.Template.Spec.Containers[0].Env,
+			corev1.EnvVar{
+				Name: envVarName,
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: secret.Name,
+						},
+						Key: mock.DataKey,
+					},
+				},
+			})
 
-		By("Checks ManifestWork was synced with secret")
-		manifestWork := &workv1.ManifestWork{}
-		Eventually(func() bool {
-			mwName := NamespaceManifestWorkPrefix + assertionCapp.Namespace + "-" + assertionCapp.Name
-			Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: mwName, Namespace: mwNamespace}, manifestWork)).Should(Succeed())
-			secret, err := utilst.IsObjInManifestWork(k8sClient, *manifestWork, secret.Name, secret.Namespace, &corev1.Secret{}, "Secret")
-			Expect(err).Should(BeNil())
-			return secret
-		}, testconsts.Timeout, testconsts.Interval).Should(BeTrue())
+		verifySecretOrConfigMapCopy(baseCapp, secret.Name, secret.Namespace, baseSecret.TypeMeta.Kind)
+	})
+
+	It("Should copy the configMap from volumes to ManifestWork", func() {
+		baseConfigMap := mock.CreateConfigMap()
+		configmap := utilst.CreateConfigMap(k8sClient, baseConfigMap)
+		baseCapp := mock.CreateBaseCapp()
+		baseCapp.Spec.ConfigurationSpec.Template.Spec.Volumes = append(
+			baseCapp.Spec.ConfigurationSpec.Template.Spec.Volumes,
+			corev1.Volume{
+				Name: configmap.Name,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: configmap.Name,
+						},
+					},
+				},
+			})
+
+		baseCapp.Spec.ConfigurationSpec.Template.Spec.Containers[0].VolumeMounts = append(
+			baseCapp.Spec.ConfigurationSpec.Template.Spec.Containers[0].VolumeMounts,
+			corev1.VolumeMount{
+				Name:      configmap.Name,
+				MountPath: "/test/mount",
+			})
+
+		verifySecretOrConfigMapCopy(baseCapp, configmap.Name, configmap.Namespace, baseConfigMap.TypeMeta.Kind)
+	})
+
+	It("Should copy the ConfigMap from environment variables to ManifestWork (envFrom)", func() {
+		baseConfigMap := mock.CreateConfigMap()
+		configmap := utilst.CreateConfigMap(k8sClient, baseConfigMap)
+		baseCapp := mock.CreateBaseCapp()
+		baseCapp.Spec.ConfigurationSpec.Template.Spec.Containers[0].EnvFrom = append(
+			baseCapp.Spec.ConfigurationSpec.Template.Spec.Containers[0].EnvFrom,
+			corev1.EnvFromSource{
+				ConfigMapRef: &corev1.ConfigMapEnvSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: configmap.Name,
+					},
+				},
+			})
+
+		verifySecretOrConfigMapCopy(baseCapp, configmap.Name, configmap.Namespace, baseConfigMap.TypeMeta.Kind)
+	})
+
+	It("Should copy the ConfigMap from environment variables to ManifestWork (valueFrom)", func() {
+		baseConfigMap := mock.CreateConfigMap()
+		configmap := utilst.CreateConfigMap(k8sClient, baseConfigMap)
+		baseCapp := mock.CreateBaseCapp()
+		baseCapp.Spec.ConfigurationSpec.Template.Spec.Containers[0].Env = append(
+			baseCapp.Spec.ConfigurationSpec.Template.Spec.Containers[0].Env,
+			corev1.EnvVar{
+				Name: envVarName,
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: configmap.Name,
+						},
+						Key: mock.DataKey,
+					},
+				},
+			})
+
+		verifySecretOrConfigMapCopy(baseCapp, configmap.Name, configmap.Namespace, baseConfigMap.TypeMeta.Kind)
 	})
 
 	It("Should copy the secret from RouteSpec to ManifestWork ", func() {
@@ -144,62 +214,23 @@ var _ = Describe("Validate the placement sync controller", func() {
 		baseCapp.Spec.RouteSpec.TlsEnabled = true
 		baseCapp.Spec.RouteSpec.TlsSecret = secret.Name
 
-		desiredCapp := utilst.CreateCapp(k8sClient, baseCapp)
-
-		By("Checks unique creation of Capp")
-		assertionCapp := utilst.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
-		Expect(assertionCapp.Name).ShouldNot(Equal(baseCapp.Name))
-
-		By("Waiting for placement to be set on Capp")
-		Eventually(func() string {
-			assertionCapp = utilst.GetCapp(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
-			return assertionCapp.Annotations[testconsts.AnnotationKeyHasPlacement]
-		}, testconsts.Timeout, testconsts.Interval).ShouldNot(Equal(""), "Should fetch capp.")
-		mwNamespace := assertionCapp.Annotations[testconsts.AnnotationKeyHasPlacement]
-
-		By("Checks ManifestWork was synced with secret")
-		manifestWork := &workv1.ManifestWork{}
-		Eventually(func() bool {
-			mwName := NamespaceManifestWorkPrefix + assertionCapp.Namespace + "-" + assertionCapp.Name
-			_ = k8sClient.Get(context.Background(), client.ObjectKey{Name: mwName, Namespace: mwNamespace}, manifestWork)
-			secret, err := utilst.IsObjInManifestWork(k8sClient, *manifestWork, secret.Name, secret.Namespace, &corev1.Secret{}, "Secret")
-			Expect(err).Should(BeNil())
-			return secret
-		}, testconsts.Timeout, testconsts.Interval).Should(BeTrue())
+		verifySecretOrConfigMapCopy(baseCapp, secret.Name, secret.Namespace, baseSecret.TypeMeta.Kind)
 	})
 
 	It("Should copy the secret from imagePullSecrets to ManifestWork ", func() {
 		baseSecret := mock.CreateSecret()
 		secret := utilst.CreateSecret(k8sClient, baseSecret)
 		baseCapp := mock.CreateBaseCapp()
-		baseCapp.Spec.ConfigurationSpec.Template.Spec.ImagePullSecrets = append(baseCapp.Spec.ConfigurationSpec.Template.Spec.ImagePullSecrets, corev1.LocalObjectReference{
-			Name: secret.Name,
-		})
-		desiredCapp := utilst.CreateCapp(k8sClient, baseCapp)
+		baseCapp.Spec.ConfigurationSpec.Template.Spec.ImagePullSecrets = append(
+			baseCapp.Spec.ConfigurationSpec.Template.Spec.ImagePullSecrets,
+			corev1.LocalObjectReference{
+				Name: secret.Name,
+			})
 
-		By("Checks unique creation of Capp")
-		assertionCapp := utilst.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
-		Expect(assertionCapp.Name).ShouldNot(Equal(baseCapp.Name))
-
-		By("Waiting for placement to be set on Capp")
-		Eventually(func() string {
-			assertionCapp = utilst.GetCapp(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
-			return assertionCapp.Annotations[testconsts.AnnotationKeyHasPlacement]
-		}, testconsts.Timeout, testconsts.Interval).ShouldNot(Equal(""), "Should fetch capp.")
-		mwNamespace := assertionCapp.Annotations[testconsts.AnnotationKeyHasPlacement]
-
-		By("Checks ManifestWork was synced with secret")
-		manifestWork := &workv1.ManifestWork{}
-		Eventually(func() bool {
-			mwName := NamespaceManifestWorkPrefix + assertionCapp.Namespace + "-" + assertionCapp.Name
-			_ = k8sClient.Get(context.Background(), client.ObjectKey{Name: mwName, Namespace: mwNamespace}, manifestWork)
-			secret, err := utilst.IsObjInManifestWork(k8sClient, *manifestWork, secret.Name, secret.Namespace, &corev1.Secret{}, "Secret")
-			Expect(err).Should(BeNil())
-			return secret
-		}, testconsts.Timeout, testconsts.Interval).Should(BeTrue())
+		verifySecretOrConfigMapCopy(baseCapp, secret.Name, secret.Namespace, baseSecret.TypeMeta.Kind)
 	})
 
-	It("Should copy the rolebindings from capp's namespace to ManifestWork ", func() {
+	It("Should copy the RoleBindings from Capp's namespace to ManifestWork ", func() {
 		baseRole := mock.CreateCappRole()
 		role := utilst.CreateRole(k8sClient, baseRole)
 		baseRoleBinding := mock.CreateCappRoleBinding()
@@ -207,46 +238,32 @@ var _ = Describe("Validate the placement sync controller", func() {
 		baseCapp := mock.CreateBaseCapp()
 		desiredCapp := utilst.CreateCapp(k8sClient, baseCapp)
 
-		By("Checks unique creation of Capp")
-		assertionCapp := utilst.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
-		Expect(assertionCapp.Name).ShouldNot(Equal(baseCapp.Name))
-
-		By("Waiting for placement to be set on Capp")
-		Eventually(func() string {
-			assertionCapp = utilst.GetCapp(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
-			return assertionCapp.Annotations[testconsts.AnnotationKeyHasPlacement]
-		}, testconsts.Timeout, testconsts.Interval).ShouldNot(Equal(""), "Should fetch capp.")
+		assertionCapp := utilst.GetCappWithPlacementAnnotation(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
 		mwNamespace := assertionCapp.Annotations[testconsts.AnnotationKeyHasPlacement]
 
-		By("Checks ManifestWork was synced with role and rolebinding")
+		By("Checks ManifestWork was synced with Role and RoleBinding")
 		manifestWork := &workv1.ManifestWork{}
+
 		Eventually(func() bool {
-			mwName := NamespaceManifestWorkPrefix + assertionCapp.Namespace + "-" + assertionCapp.Name
+			mwName := namespaceManifestWorkPrefix + assertionCapp.Namespace + "-" + assertionCapp.Name
 			_ = k8sClient.Get(context.Background(), client.ObjectKey{Name: mwName, Namespace: mwNamespace}, manifestWork)
 			return utilst.IsRbacObjInManifestWork(*manifestWork, assertionCapp.Name, role.Namespace, "Role") &&
 				utilst.IsRbacObjInManifestWork(*manifestWork, assertionCapp.Name, roleBinding.Namespace, "RoleBinding")
 		}, testconsts.Timeout, testconsts.Interval).Should(BeTrue())
 	})
 
-	It("Should copy the capp and capp's namespace to ManifestWork ", func() {
+	It("Should copy the Capp and Capp's namespace to ManifestWork ", func() {
 		baseCapp := mock.CreateBaseCapp()
 		desiredCapp := utilst.CreateCapp(k8sClient, baseCapp)
 
-		By("Checks unique creation of Capp")
-		assertionCapp := utilst.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
-		Expect(assertionCapp.Name).ShouldNot(Equal(baseCapp.Name))
-
-		By("Waiting for placement to be set on Capp")
-		Eventually(func() string {
-			assertionCapp = utilst.GetCapp(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
-			return assertionCapp.Annotations[testconsts.AnnotationKeyHasPlacement]
-		}, testconsts.Timeout, testconsts.Interval).ShouldNot(Equal(""), "Should fetch capp.")
+		assertionCapp := utilst.GetCappWithPlacementAnnotation(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
 		mwNamespace := assertionCapp.Annotations[testconsts.AnnotationKeyHasPlacement]
 
-		By("Checks ManifestWork was synced with capp and namespace")
+		By("Checks ManifestWork was synced with Capp and namespace")
 		manifestWork := &workv1.ManifestWork{}
+
 		Eventually(func() bool {
-			mwName := NamespaceManifestWorkPrefix + assertionCapp.Namespace + "-" + assertionCapp.Name
+			mwName := namespaceManifestWorkPrefix + assertionCapp.Namespace + "-" + assertionCapp.Name
 			_ = k8sClient.Get(context.Background(), client.ObjectKey{Name: mwName, Namespace: mwNamespace}, manifestWork)
 			ns, err := utilst.IsObjInManifestWork(k8sClient, *manifestWork, assertionCapp.Namespace, "", &corev1.Namespace{}, "Namespace")
 			Expect(err).Should(BeNil())
@@ -256,19 +273,11 @@ var _ = Describe("Validate the placement sync controller", func() {
 		}, testconsts.Timeout, testconsts.Interval).Should(BeTrue())
 	})
 
-	It("Should copy the updated capp to ManifestWork ", func() {
+	It("Should copy the updated Capp to ManifestWork ", func() {
 		baseCapp := mock.CreateBaseCapp()
 		desiredCapp := utilst.CreateCapp(k8sClient, baseCapp)
 
-		By("Checks unique creation of Capp")
-		assertionCapp := utilst.GetCapp(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
-		Expect(assertionCapp.Name).ShouldNot(Equal(baseCapp.Name))
-
-		By("Waiting for placement to be set on Capp")
-		Eventually(func() string {
-			assertionCapp = utilst.GetCapp(k8sClient, assertionCapp.Name, assertionCapp.Namespace)
-			return assertionCapp.Annotations[testconsts.AnnotationKeyHasPlacement]
-		}, testconsts.Timeout, testconsts.Interval).ShouldNot(Equal(""), "Should fetch capp.")
+		assertionCapp := utilst.GetCappWithPlacementAnnotation(k8sClient, desiredCapp.Name, desiredCapp.Namespace)
 		mwNamespace := assertionCapp.Annotations[testconsts.AnnotationKeyHasPlacement]
 
 		By("Update Capp")
@@ -277,13 +286,13 @@ var _ = Describe("Validate the placement sync controller", func() {
 
 		By("Checks Capp site is not nil")
 		manifestWork := &workv1.ManifestWork{}
-		mwName := NamespaceManifestWorkPrefix + assertionCapp.Namespace + "-" + assertionCapp.Name
+		mwName := namespaceManifestWorkPrefix + assertionCapp.Namespace + "-" + assertionCapp.Name
 		Eventually(func() interface{} {
 			_ = k8sClient.Get(context.Background(), client.ObjectKey{Name: mwName, Namespace: mwNamespace}, manifestWork)
 			return utilst.GetCappFromManifestWork(*manifestWork).Object["spec"].(map[string]interface{})["site"]
 		}, testconsts.Timeout, testconsts.Interval).ShouldNot(BeNil())
 
-		By("Checks ManifestWork was synced with new capp")
+		By("Checks ManifestWork was synced with new Capp")
 		Eventually(func() string {
 			_ = k8sClient.Get(context.Background(), client.ObjectKey{Name: mwName, Namespace: mwNamespace}, manifestWork)
 			return utilst.GetCappFromManifestWork(*manifestWork).Object["spec"].(map[string]interface{})["site"].(string)

--- a/test/e2e_tests/utils/capp_adpater.go
+++ b/test/e2e_tests/utils/capp_adpater.go
@@ -5,6 +5,8 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/dana-team/rcs-ocm-deployer/test/e2e_tests/testconsts"
+
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -72,4 +74,16 @@ func DoesFinalizerExist(k8sClient client.Client, cappName string, cappNamespace 
 		}
 	}
 	return false
+}
+
+// GetCappWithPlacementAnnotation checks whether a Capp eventually has a placement annotation.
+// If it exists then it returns an up-to-date Capp which contains the annotation.
+func GetCappWithPlacementAnnotation(k8sClient client.Client, name, namespace string) *cappv1alpha1.Capp {
+	capp := &cappv1alpha1.Capp{}
+	Eventually(func() string {
+		capp = GetCapp(k8sClient, name, namespace)
+		return capp.Annotations[testconsts.AnnotationKeyHasPlacement]
+	}, testconsts.Timeout, testconsts.Interval).ShouldNot(Equal(""), "Should have placement annotation on Capp.")
+
+	return capp
 }

--- a/test/e2e_tests/utils/manifestwork_adapter.go
+++ b/test/e2e_tests/utils/manifestwork_adapter.go
@@ -8,25 +8,24 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	RbacObjectSuffix = "-logs-reader"
-)
+const RbacObjectSuffix = "-logs-reader"
 
-// convertManifestToUnstructred gets a manifest from a ManifestWork, which is a slice of bytes and returns it as an unstructred object
-func convertManifestToUnstructred(manifest []byte) (unstructured.Unstructured, error) {
+// convertManifestToUnstructured gets a manifest from a ManifestWork, which is a slice of bytes and returns it as an unstructured object.
+func convertManifestToUnstructured(manifest []byte) (unstructured.Unstructured, error) {
 	unstructuredObj := &unstructured.Unstructured{}
 	err := unstructuredObj.UnmarshalJSON(manifest)
 	return *unstructuredObj, err
 }
 
-// IsObjInManifestWork checks if a given object is in the ManifestWork's manifests list
+// IsObjInManifestWork checks if a given object is in the ManifestWork's manifests list.
 func IsObjInManifestWork(k8sClient client.Client, manifestWork workv1.ManifestWork, objName string, objNamespace string, object client.Object, kind string) (bool, error) {
 	err := k8sClient.Get(context.Background(), client.ObjectKey{Name: objName, Namespace: objNamespace}, object)
 	if err != nil {
 		return false, err
 	}
+
 	for _, manifest := range manifestWork.Spec.Workload.Manifests {
-		obj, err := convertManifestToUnstructred(manifest.Raw)
+		obj, err := convertManifestToUnstructured(manifest.Raw)
 		if err != nil {
 			return false, err
 		} else {
@@ -35,13 +34,14 @@ func IsObjInManifestWork(k8sClient client.Client, manifestWork workv1.ManifestWo
 			}
 		}
 	}
+
 	return false, nil
 }
 
-// IsRbacObjInManifestWork checks if a given  role/rolebinding object is in the ManifestWork's manifests list
+// IsRbacObjInManifestWork checks if a given role/rolebinding object is in the ManifestWork's manifests list.
 func IsRbacObjInManifestWork(manifestWork workv1.ManifestWork, cappName string, nsName string, kind string) bool {
 	for _, manifest := range manifestWork.Spec.Workload.Manifests {
-		obj, err := convertManifestToUnstructred(manifest.Raw)
+		obj, err := convertManifestToUnstructured(manifest.Raw)
 		if err != nil {
 			return false
 		} else {
@@ -53,10 +53,10 @@ func IsRbacObjInManifestWork(manifestWork workv1.ManifestWork, cappName string, 
 	return false
 }
 
-// GetCappFromManifestWork returns a Capp from its corresponding ManifestWork
+// GetCappFromManifestWork returns a Capp from its corresponding ManifestWork.
 func GetCappFromManifestWork(manifestWork workv1.ManifestWork) unstructured.Unstructured {
 	for _, manifest := range manifestWork.Spec.Workload.Manifests {
-		obj, err := convertManifestToUnstructred(manifest.Raw)
+		obj, err := convertManifestToUnstructured(manifest.Raw)
 		if err != nil {
 			return unstructured.Unstructured{}
 		} else if obj.GetKind() == "Capp" {

--- a/test/e2e_tests/utils/resources_adapter.go
+++ b/test/e2e_tests/utils/resources_adapter.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// IsSiteInPlacement checks if a given site is part of a clusterset mentioned in a placement
+// IsSiteInPlacement checks if a given site is part of a clusterset mentioned in a placement.
 func IsSiteInPlacement(k8sClient client.Client, placementName string, placementNamespace string) (bool, error) {
 	placement := clusterv1beta1.Placement{}
 	var clusterSets []string
@@ -40,41 +40,51 @@ func IsSiteInPlacement(k8sClient client.Client, placementName string, placementN
 	return false, nil
 }
 
-// CreateSecret creates a corev1.secret object with a random suffix in its name and returns it
+// CreateSecret creates a corev1.secret object with a random suffix in its name and returns it.
 func CreateSecret(k8sClient client.Client, secret *corev1.Secret) *corev1.Secret {
-	secret.Name = GenerateUniqueSecretName(secret.Name)
-	Expect(k8sClient.Create(context.Background(), secret)).To(Succeed())
-	return secret
+	secret.Name = GenerateUniqueName(secret.Name)
+	newSecret := secret.DeepCopy()
+	Expect(k8sClient.Create(context.Background(), newSecret)).To(Succeed())
+	return newSecret
+}
+
+// CreateConfigMap creates a corev1.configMap object with a random suffix in its name and returns it
+func CreateConfigMap(k8sClient client.Client, configmap *corev1.ConfigMap) *corev1.ConfigMap {
+	configmap.Name = GenerateUniqueName(configmap.Name)
+	newConfigMap := configmap.DeepCopy()
+	Expect(k8sClient.Create(context.Background(), newConfigMap)).To(Succeed())
+	return newConfigMap
 }
 
 // CreateTlsSecret creates a tls typed corev1.secret with a random suffix in its name and returns it.
 func CreateTlsSecret(k8sClient client.Client, secret *corev1.Secret) *corev1.Secret {
-	secret.Name = GenerateUniqueSecretName(secret.Name)
+	secret.Name = GenerateUniqueName(secret.Name)
 	secret.Type = corev1.SecretTypeTLS
 	secret.Data = map[string][]byte{
 		"tls.crt": []byte("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----"),
 		"tls.key": []byte("-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----"),
 	}
-	Expect(k8sClient.Create(context.Background(), secret)).To(Succeed())
+	newSecret := secret.DeepCopy()
+	Expect(k8sClient.Create(context.Background(), newSecret)).To(Succeed())
 	Eventually(func() bool {
-		return DoesResourceExist(k8sClient, secret)
+		return DoesResourceExist(k8sClient, newSecret)
 	}, testconsts.Timeout, testconsts.Interval).Should(BeTrue())
-	return secret
+	return newSecret
 }
 
-// GenerateUniqueSecretName generates a unique Secret name.
-func GenerateUniqueSecretName(baseSecretName string) string {
+// GenerateUniqueName generates a unique name.
+func GenerateUniqueName(baseSecretName string) string {
 	randString := generateRandomString(RandStrLength)
 	return baseSecretName + "-" + randString
 }
 
-// CreateRole creates a rbac1.Role object and returns it
+// CreateRole creates a rbac1.Role object and returns it.
 func CreateRole(k8sClient client.Client, role *rbacv1.Role) *rbacv1.Role {
 	Expect(k8sClient.Create(context.Background(), role)).To(Succeed())
 	return role
 }
 
-// CreateRoleBinding creates a rbacv1.RoleBinding and returns it
+// CreateRoleBinding creates a rbacv1.RoleBinding and returns it.
 func CreateRoleBinding(k8sClient client.Client, roleBinding *rbacv1.RoleBinding) *rbacv1.RoleBinding {
 	Expect(k8sClient.Create(context.Background(), roleBinding)).To(Succeed())
 	return roleBinding


### PR DESCRIPTION
This PR adds support for copying secrets from Capp to the ManifestWork when the secrets are referenced using the valueFrom field in a PodSpec