### PR TITLE
test: remove tlsSecret tests due to field removal

### DIFF
--- a/hack/setup-rcs-deployer.sh
+++ b/hack/setup-rcs-deployer.sh
@@ -87,6 +87,7 @@ kubectl wait --for=condition=ready pods -l control-plane=controller-manager -n c
 if [ -n "$rcsimage" ] && [ "$rcsimage" != "controller:latest" ]; then
   "${kind}" load docker-image ${rcsimage} --name "${c1}"
 fi
+kubectl create configmap dns-zone --from-literal=zone=capp-zone. -n capp-operator-system
 
 kubectl config use-context "${c2ctx}"
 make -C container-app-operator prereq
@@ -95,6 +96,7 @@ kubectl wait --for=condition=ready pods -l control-plane=controller-manager -n c
 if [ -n "$rcsimage" ] && [ "$rcsimage" != "controller:latest" ]; then
   "${kind}" load docker-image ${rcsimage} --name "${c2}"
 fi
+kubectl create configmap dns-zone --from-literal=zone=capp-zone. -n capp-operator-system
 
 rm -rf container-app-operator/
 

--- a/test/e2e_tests/helper.go
+++ b/test/e2e_tests/helper.go
@@ -1,6 +1,7 @@
 package e2e_tests
 
 import (
+	"github.com/go-logr/logr"
 	"k8s.io/client-go/rest"
 
 	cappv1alpha1 "github.com/dana-team/container-app-operator/api/v1alpha1"
@@ -23,6 +24,7 @@ import (
 var (
 	k8sClient client.Client
 	cfg       *rest.Config
+	logger    logr.Logger
 )
 
 func newScheme() *runtime.Scheme {

--- a/test/e2e_tests/mocks/base.go
+++ b/test/e2e_tests/mocks/base.go
@@ -14,7 +14,7 @@ var (
 	cappConfigMapName = "capp-config"
 	cappAdmin         = "capp-admin"
 	cappName          = "capp-default-test"
-	cappBaseImage     = "ghcr.io/knative/autoscale-go:latest"
+	cappBaseImage     = "ghcr.io/dana-team/capp-gin-app:v0.2.0"
 	DataKey           = "password"
 	DataValue         = "password"
 	KindConfigMap     = "ConfigMap"

--- a/test/e2e_tests/suite_test.go
+++ b/test/e2e_tests/suite_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func TestE2E(t *testing.T) {
@@ -41,6 +42,7 @@ var _ = SynchronizedAfterSuite(func() {}, func() {
 // initClient initializes a k8s client.
 func initClient() {
 	var err error
+	log.SetLogger(logger)
 	cfg, err = config.GetConfig()
 	Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e_tests/sync.go
+++ b/test/e2e_tests/sync.go
@@ -207,16 +207,6 @@ var _ = Describe("Validate the placement sync controller", func() {
 		verifySecretOrConfigMapCopy(baseCapp, configmap.Name, configmap.Namespace, baseConfigMap.TypeMeta.Kind)
 	})
 
-	It("Should copy the secret from RouteSpec to ManifestWork ", func() {
-		baseSecret := mock.CreateSecret()
-		secret := utilst.CreateTlsSecret(k8sClient, baseSecret)
-		baseCapp := mock.CreateBaseCapp()
-		baseCapp.Spec.RouteSpec.TlsEnabled = true
-		baseCapp.Spec.RouteSpec.TlsSecret = secret.Name
-
-		verifySecretOrConfigMapCopy(baseCapp, secret.Name, secret.Namespace, baseSecret.TypeMeta.Kind)
-	})
-
 	It("Should copy the secret from imagePullSecrets to ManifestWork ", func() {
 		baseSecret := mock.CreateSecret()
 		secret := utilst.CreateSecret(k8sClient, baseSecret)

--- a/test/e2e_tests/utils/resources_adapter.go
+++ b/test/e2e_tests/utils/resources_adapter.go
@@ -3,8 +3,6 @@ package utils
 import (
 	"context"
 
-	"github.com/dana-team/rcs-ocm-deployer/test/e2e_tests/testconsts"
-
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -54,22 +52,6 @@ func CreateConfigMap(k8sClient client.Client, configmap *corev1.ConfigMap) *core
 	newConfigMap := configmap.DeepCopy()
 	Expect(k8sClient.Create(context.Background(), newConfigMap)).To(Succeed())
 	return newConfigMap
-}
-
-// CreateTlsSecret creates a tls typed corev1.secret with a random suffix in its name and returns it.
-func CreateTlsSecret(k8sClient client.Client, secret *corev1.Secret) *corev1.Secret {
-	secret.Name = GenerateUniqueName(secret.Name)
-	secret.Type = corev1.SecretTypeTLS
-	secret.Data = map[string][]byte{
-		"tls.crt": []byte("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----"),
-		"tls.key": []byte("-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----"),
-	}
-	newSecret := secret.DeepCopy()
-	Expect(k8sClient.Create(context.Background(), newSecret)).To(Succeed())
-	Eventually(func() bool {
-		return DoesResourceExist(k8sClient, newSecret)
-	}, testconsts.Timeout, testconsts.Interval).Should(BeTrue())
-	return newSecret
 }
 
 // GenerateUniqueName generates a unique name.

--- a/test/e2e_tests/validating.go
+++ b/test/e2e_tests/validating.go
@@ -3,13 +3,11 @@ package e2e_tests
 import (
 	"context"
 
-	"github.com/dana-team/rcs-ocm-deployer/test/e2e_tests/testconsts"
 	utilst "github.com/dana-team/rcs-ocm-deployer/test/e2e_tests/utils"
 
 	mock "github.com/dana-team/rcs-ocm-deployer/test/e2e_tests/mocks"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -95,38 +93,6 @@ var _ = Describe("Validate the validating webhook", func() {
 		baseCapp.Spec.LogSpec.User = elasticUser
 		baseCapp.Spec.LogSpec.PasswordSecret = secretName
 		Expect(k8sClient.Create(context.Background(), baseCapp)).Should(Succeed())
-	})
-
-	It("should deny the use of Opaque secret in tls spec", func() {
-		baseCapp := mock.CreateBaseCapp()
-		baseCapp.Name = utilst.GenerateUniqueCappName(baseCapp.Name)
-		baseSecret := mock.CreateSecret()
-		baseSecret.Type = corev1.SecretTypeOpaque
-		utilst.CreateSecret(k8sClient, baseSecret)
-		Eventually(func() bool {
-			return utilst.DoesResourceExist(k8sClient, baseSecret)
-		}, testconsts.Timeout, testconsts.Interval).Should(BeTrue())
-		baseCapp.Spec.RouteSpec.TlsEnabled = true
-		baseCapp.Spec.RouteSpec.TlsSecret = baseSecret.Name
-		Expect(k8sClient.Create(context.Background(), baseCapp)).ShouldNot(Succeed())
-	})
-
-	It("should allow the use of tls secret in tls spec", func() {
-		baseCapp := mock.CreateBaseCapp()
-		baseCapp.Name = utilst.GenerateUniqueCappName(baseCapp.Name)
-		baseSecret := mock.CreateSecret()
-		baseSecret = utilst.CreateTlsSecret(k8sClient, baseSecret)
-		baseCapp.Spec.RouteSpec.TlsEnabled = true
-		baseCapp.Spec.RouteSpec.TlsSecret = baseSecret.Name
-		Expect(k8sClient.Create(context.Background(), baseCapp)).Should(Succeed())
-	})
-
-	It("should deny the option of giving non existent secret in tls spec", func() {
-		baseCapp := mock.CreateBaseCapp()
-		baseCapp.Name = utilst.GenerateUniqueCappName(baseCapp.Name)
-		baseCapp.Spec.RouteSpec.TlsEnabled = true
-		baseCapp.Spec.RouteSpec.TlsSecret = "notexistsecret"
-		Expect(k8sClient.Create(context.Background(), baseCapp)).ShouldNot(Succeed())
 	})
 
 })


### PR DESCRIPTION
The tlsSecret has been removed from Capp spec (route spec) and so the tests that address this field have been removed