### PR TITLE
cleanup: remove tlsSecret validation from webhook

### DIFF
--- a/internal/webhooks/capp_validator_webhook.go
+++ b/internal/webhooks/capp_validator_webhook.go
@@ -59,9 +59,6 @@ func (c *CappValidator) handle(ctx context.Context, capp cappv1alpha1.Capp) admi
 	if errs := validateDomainName(capp.Spec.RouteSpec.Hostname); errs != nil {
 		return admission.Denied(errs.Error())
 	}
-	if errs := validateTlsFields(capp, c.Client, ctx); errs != nil {
-		return admission.Denied(errs.Error())
-	}
 	if capp.Spec.LogSpec != (cappv1alpha1.LogSpec{}) {
 		if errs := validateLogSpec(capp.Spec.LogSpec); errs != nil {
 			return admission.Denied(errs.Error())


### PR DESCRIPTION
The tlsSecret field has been removed from the API and so the webhook validation that existed in the code has been removed.