### PR TITLE
feat: refactor mutator to exclude service accounts within rcs-deployer-system namespace

### DIFF
--- a/test/e2e_tests/mocks/base.go
+++ b/test/e2e_tests/mocks/base.go
@@ -148,12 +148,16 @@ func CreateRoleBinding(name string, roleRef rbacv1.RoleRef, subjects []rbacv1.Su
 	}
 }
 
-// CreateServiceAccount creates a service account with the specified name.
-func CreateServiceAccount(name string) *corev1.ServiceAccount {
+// CreateServiceAccount creates a service account with the specified name in the specified namespace.
+func CreateServiceAccount(name, namespace string) *corev1.ServiceAccount {
+	if namespace == "" {
+		namespace = NSName
+	}
+
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: NSName,
+			Namespace: namespace,
 		},
 	}
 }

--- a/test/e2e_tests/suite_test.go
+++ b/test/e2e_tests/suite_test.go
@@ -30,12 +30,14 @@ var _ = SynchronizedBeforeSuite(func() {
 	cleanUp()
 	createE2ETestNamespace()
 	utilst.CreateTestUser(k8sClient, mock.NSName)
+	utilst.CreateExcludedServiceAccount(k8sClient)
 }, func() {
 	initClient()
 })
 
 var _ = SynchronizedAfterSuite(func() {}, func() {
 	utilst.DeleteTestUser(k8sClient, mock.NSName)
+	utilst.DeleteExcludedServiceAccount(k8sClient)
 	cleanUp()
 })
 

--- a/test/e2e_tests/utils/resources_adapter.go
+++ b/test/e2e_tests/utils/resources_adapter.go
@@ -71,3 +71,9 @@ func CreateRoleBinding(k8sClient client.Client, roleBinding *rbacv1.RoleBinding)
 	Expect(k8sClient.Create(context.Background(), roleBinding)).To(Succeed())
 	return roleBinding
 }
+
+// CreateServiceAccount creates a corev1.ServiceAccount and returns it.
+func CreateServiceAccount(k8sClient client.Client, serviceAccount *corev1.ServiceAccount) *corev1.ServiceAccount {
+	Expect(k8sClient.Create(context.Background(), serviceAccount)).To(Succeed())
+	return serviceAccount
+}


### PR DESCRIPTION
This update modifies the mutator logic so that updates to `Capp`, made by service accounts within the `rcs-deployer-system` namespace, do not add or modify the `last updated by` annotation. 
The change ensures that only service accounts outside this namespace are affected by the mutator.